### PR TITLE
cicd 배포시 캐시 안쌓이게 조치

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,23 +23,16 @@ jobs:
           script: |
             cd /home/ubuntu/dreamcenter/backend
 
-            echo ">> STEP 1: git pull"
             git pull origin main
 
-            echo ">> STEP 2: 디스크 상태 확인"
-            df -h
-            docker system df
-
-            echo ">> STEP 3: 도커 정리"
             docker system prune -af --volumes
 
-            echo ">> STEP 4: 컨테이너 종료"
             docker-compose down
 
-            echo ">> STEP 5: 도커 빌드"
-            docker-compose build
+            docker build --no-cache -t myapp:latest .
 
-            echo ">> STEP 6: 컨테이너 시작"
             docker-compose up -d
+
+            docker system df
 
             echo "✅ 모든 작업 완료"


### PR DESCRIPTION
## 문제 발생
- deploy.yml 파일에 CI/CD 자동배포 시 도커 이미지로 인해 캐시 용량이 부족해지는 문제 지속 발생
## 해결
- docker system prune -af --volumes : 용량 제거 코드 삽입
- docker build --no-cache -t myapp:latest . : 캐시를 쌓지 않고 빌드하는 방식 채택
- docker system df : 실시간 용량 확인 가능하도록 조치