### PR TITLE
뉴스 페이지 RSS 받아오기 완료 및 뉴스 카드 제작 구현

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,9 @@ FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 
 # Nginx 설정 파일 덮어씌우고 싶다면 필요시 추가 가능
-# COPY ./nginx.conf /etc/nginx/nginx.conf
+# 새로고침시 404페이지 오류뜨는것 대응
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+
 
 EXPOSE 80
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/components/pages/Client/NewsPage.tsx
+++ b/frontend/src/components/pages/Client/NewsPage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { getNews } from "../../../api/postApi";
+import CurrentRoot from "../../common/CurrentRoot";
+import styled from "styled-components";
 
 interface NewsDataProps {
   date: string;
@@ -9,6 +11,58 @@ interface NewsDataProps {
   title: string;
 }
 
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  h2 {
+    margin-bottom: 12px;
+  }
+  button {
+    align-self: flex-end;
+    background-color: #49b736;
+    font-size: 16px;
+    font-weight: 400;
+    color: white;
+    padding: 12px 40px;
+    border: none;
+    cursor: pointer;
+    margin-bottom: 60px;
+  }
+`;
+
+const LinkBlock = styled.a<{ $imageUrl: string }>`
+  display: block;
+  text-decoration: none;
+  color: inherit;
+
+  padding: 40px 28px;
+  border-radius: 10px;
+  width: 30%;
+  background-color: #f8f8f8;
+  text-align: left;
+
+  h3 {
+    margin-bottom: 8px;
+    line-height: 1.4;
+  }
+  p {
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 5; /* 최대 4줄까지만 보이게 */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+`;
+const Source = styled.span`
+  color: #49b736;
+  display: block;
+  margin-bottom: 16px;
+`;
+const Date = styled.span`
+  display: block;
+  margin-bottom: 16px;
+`;
 export default function NewsPage() {
   const [newsList, setNewsList] = useState<NewsDataProps[]>([]);
 
@@ -20,6 +74,22 @@ export default function NewsPage() {
     };
     axiosData();
   }, []);
-  console.log(newsList[0].title);
-  return <div></div>;
+
+  return (
+    <Div>
+      <h2 className="Section-title">오시는 길</h2>
+      <CurrentRoot root1={"소식"} />
+      <button>블로그 동기화</button>
+      <section>
+        <LinkBlock href={newsList[0]?.link} $imageUrl={newsList[0]?.img}>
+          <article>
+            <Source>네이버 블로그</Source>
+            <h3 className="middle-title">{newsList[0]?.title}</h3>
+            <Date className="description">{newsList[0]?.date}</Date>
+            <p className="paragraph">{newsList[0]?.description}</p>
+          </article>
+        </LinkBlock>
+      </section>
+    </Div>
+  );
 }

--- a/frontend/src/style/global.css
+++ b/frontend/src/style/global.css
@@ -30,3 +30,17 @@ body {
   padding-left: 16px;
   background-clip: padding-box;
 }
+.middle-title {
+  font-size: 24px;
+  font-weight: 700;
+}
+.description {
+  font-size: 14px;
+  color: #888888;
+  font-weight: 400;
+}
+
+.paragraph {
+  font-size: 16px;
+  font-weight: 400;
+}


### PR DESCRIPTION
<img width="1405" alt="스크린샷 2025-05-14 오전 1 22 46" src="https://github.com/user-attachments/assets/5f005ece-4429-4370-bd1e-6399ecf142ff" />

## 구현 사항
- 뉴스 페이지 RSS 데이터 백엔드 정리 후 프론트로 불러오기 완료
- 뉴스 페이지 기본 레이아웃 및 버튼 구현 완료 
- 받아온 RSS 데이터를 기반으로 뉴스 카드 구현 완료 및 클릭 시 블로그 이동 확인 

## 미비된 사항
- 버튼의 블로그 동기화 기능 제작 예정
- 뉴스 카드 컴포넌트로 추출 예정
- map 함수를 기반으로 반복 렌더링 예정
