### PR TITLE
fix: nginx.conf 경로 수정

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,6 @@ RUN npm run build
 
 # 2단계: 정적 서버용 이미지
 FROM nginx:alpine
-
 COPY --from=build /app/build /usr/share/nginx/html
 
 # Nginx 설정 파일 덮어씌우고 싶다면 필요시 추가 가능

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,4 +8,10 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    location /api/ {
+        proxy_pass http://my-backend:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
 }


### PR DESCRIPTION
# 문제
- 로컬의 백엔드 연결 경로가 /api로 시작하는 문제 발생
- 배포 시 경로를 찾을수가 없어서 제대로 백엔드 연결이 안되는 문제 발생
- nginx.conf를 수정해서 /api/ 경로를 추가시키고 재 커밋
