### PR TITLE
Dev

### DIFF
--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -515,7 +515,7 @@ exports.GetPageCount = async (req, res) => {
   const token = req.cookies.token;
   // 10개로 바꾸기
   // 한페이지에 받아올 아이템 수
-  const limit = 2;
+  const limit = 1;
 
   // 시작 인덱스 구하기
   const startIndex = (page - 1) * limit;
@@ -534,6 +534,7 @@ exports.GetPageCount = async (req, res) => {
         TotalItems = await ReservationSubmit.findAll({
           limit: limit,
           offset: startIndex,
+          order: [["createdAt", "DESC"]],
         });
         break;
 

--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -41,7 +41,6 @@ exports.postUpload = [
 
       const ext = path.extname(file.originalname); // 확장자 추출
       const key = `uploads/${uuidv4()}_${ext}`;
-      console.log(key);
 
       const uploadParams = {
         Bucket: process.env.AWS_BUCKET_NAME,
@@ -80,7 +79,6 @@ exports.postLogin = async (req, res) => {
       }
     );
     const { access_token } = tokenResponse.data;
-    console.log("@@@@@여기까진 성공", access_token);
 
     // access_token을 가지고 사용자 정보 요청
     const profileResponse = await axios.get(
@@ -95,7 +93,6 @@ exports.postLogin = async (req, res) => {
     const userData = profileResponse.data.response;
     // DB에 해당 유저가 저장되어 있는지 확인
     let existingUser = await User.findOne({ where: { sns_id: userData.id } });
-    // console.log("유저데이타", existingUser);
     let user;
     // 정보가 없다면 유저 정보 기반으로 자동 회원가입 개시
     if (!existingUser) {
@@ -436,8 +433,6 @@ exports.PostReservationSubmit = [
     try {
       // 사용자 토큰 제작시 사용했던 ID 추출
       const decoded = jwt.verify(token, process.env.JWT_SECRET);
-      console.log(decoded.userID);
-      console.log(req.body);
       const uploadedUrls = [];
       for (const file of files) {
         const ext = path.extname(file.originalname);
@@ -500,5 +495,16 @@ exports.GetReservationSubmit = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "내 신청내역 가져오기 실패(서버)" });
+  }
+};
+
+exports.PostReservationDelete = async (req, res) => {
+  try {
+    const IdArr = req.body.deleteArray;
+    await ReservationSubmit.destroy({ where: { id: IdArr } });
+    res.status(200).json({ message: "삭제 성공" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "내 신청내역 삭제하기 실패(서버)" });
   }
 };

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -20,6 +20,7 @@ const {
   PostReservationSubmit,
   getUserInfo,
   GetReservationSubmit,
+  PostReservationDelete,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -39,5 +40,6 @@ router.get("/about/getWrite", GetAboutWrite);
 router.get("/office/getWrite", GetOfficeWrite);
 router.post("/reservation/postSubmit", PostReservationSubmit);
 router.get("/reservation/getSubmit", GetReservationSubmit);
+router.post("/reservation/postDelete", PostReservationDelete);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -21,6 +21,7 @@ const {
   getUserInfo,
   GetReservationSubmit,
   PostReservationDelete,
+  GetPageCount,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -41,5 +42,6 @@ router.get("/office/getWrite", GetOfficeWrite);
 router.post("/reservation/postSubmit", PostReservationSubmit);
 router.get("/reservation/getSubmit", GetReservationSubmit);
 router.post("/reservation/postDelete", PostReservationDelete);
+router.get("/pagecount", GetPageCount);
 
 module.exports = router;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.2",
     "axios": "^1.8.4",
+    "html-entities": "^2.6.0",
     "react": "^19.1.0",
     "react-datepicker": "^8.3.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -187,3 +187,14 @@ export const GetReservation = async () => {
     console.error("상담 신청내역 불러오기 실패", err);
   }
 };
+
+export const PostDeleteReservation = async (deleteArray: number[]) => {
+  try {
+    const response = await API.post(`/api/reservation/postDelete`, {
+      deleteArray,
+    });
+    return response.data;
+  } catch (err) {
+    console.error("상담 신청내역 삭제하기 실패", err);
+  }
+};

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -198,3 +198,24 @@ export const PostDeleteReservation = async (deleteArray: number[]) => {
     console.error("상담 신청내역 삭제하기 실패", err);
   }
 };
+
+export const GetPageCount = async (DB: string, index: number) => {
+  try {
+    // 받는 문자열에 맞춰서 어떤 DB에서 탐색 진행할건지를 고른다.
+    const response = await API.get(`/api/pagecount`, {
+      params: { type: DB, page: index },
+    });
+    return response.data;
+  } catch (err) {
+    console.error("신청 내역 개수 불러오기 실패", err);
+  }
+};
+// export const GetPageItems = async (DB: string) => {
+//   try {
+//     // 받는 문자열에 맞춰서 어떤 DB에서 탐색 진행할건지를 고른다.
+//     const response = await API.get(`/api/pagecount`, { params: { type: DB } });
+//     return response.data;
+//   } catch (err) {
+//     console.error("신청 내역 개수 불러오기 실패", err);
+//   }
+// };

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -210,12 +210,3 @@ export const GetPageCount = async (DB: string, index: number) => {
     console.error("신청 내역 개수 불러오기 실패", err);
   }
 };
-// export const GetPageItems = async (DB: string) => {
-//   try {
-//     // 받는 문자열에 맞춰서 어떤 DB에서 탐색 진행할건지를 고른다.
-//     const response = await API.get(`/api/pagecount`, { params: { type: DB } });
-//     return response.data;
-//   } catch (err) {
-//     console.error("신청 내역 개수 불러오기 실패", err);
-//   }
-// };

--- a/frontend/src/components/common/CurrentRoot.tsx
+++ b/frontend/src/components/common/CurrentRoot.tsx
@@ -63,7 +63,7 @@ export default function CurrentRoot({
         viewBox="0 0 16 16"
       >
         <path
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
         />
       </svg>
@@ -81,7 +81,7 @@ export default function CurrentRoot({
             viewBox="0 0 16 16"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
             />
           </svg>

--- a/frontend/src/components/common/FooterLayout.tsx
+++ b/frontend/src/components/common/FooterLayout.tsx
@@ -10,7 +10,7 @@ const Footer = styled.footer`
   div {
     max-width: 1200px;
     width: 100%;
-    padding: 40px 0;
+    padding: 20px 0;
 
     h2 {
       font-size: 18px;

--- a/frontend/src/components/common/LoginControl.tsx
+++ b/frontend/src/components/common/LoginControl.tsx
@@ -38,8 +38,6 @@ export default function LoginControl() {
     try {
       const response = await postLogout();
       setIsLogin(false);
-
-      console.log(response.message);
     } catch (error) {
       console.error("로그아웃 실패", error);
     }

--- a/frontend/src/components/common/PageCountUI.tsx
+++ b/frontend/src/components/common/PageCountUI.tsx
@@ -1,0 +1,174 @@
+import { GetPageCount } from "@/api/postApi";
+import React, { SetStateAction, useEffect, useState } from "react";
+import styled from "styled-components";
+import { FormData } from "@/types/forms";
+import { ReservationMyListStore } from "@/store/userStore";
+const Div = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 70px auto 0;
+
+  .arrowButton {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: none;
+    background-color: transparent;
+    color: #888888;
+    width: 25px;
+    height: 25px;
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    &:hover {
+      color: #49b736;
+    }
+  }
+`;
+
+const Ul = styled.ul`
+  display: flex;
+  align-items: center;
+  color: #888888;
+  gap: 8px;
+  margin: 0 24px;
+
+  li {
+    .Countselected {
+      background-color: #49b736;
+      color: white;
+      cursor: default;
+    }
+  }
+`;
+
+const PageButton = styled.button`
+  background-color: transparent;
+  border: none;
+  color: #888888;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  margin: auto;
+  line-height: 30px;
+  cursor: pointer;
+  font-size: 16px;
+`;
+
+interface MyListSectionProps {
+  form: FormData[];
+  setForm: React.Dispatch<SetStateAction<FormData[]>>;
+  type: string;
+}
+
+export default function PageCountUI({
+  form,
+  setForm,
+  type,
+}: MyListSectionProps) {
+  const { pageCount, setPageCount, currentPage, setCurrentPage } =
+    ReservationMyListStore();
+
+  const PageCount = async () => {
+    const res = await GetPageCount(type, currentPage);
+    setPageCount(Array.from({ length: res.result }, (_, i) => i + 1));
+    setForm(res.TotalItems);
+  };
+
+  useEffect(() => {
+    // 현재 페이지 값이 바뀐게 확인되어야만 데이터를 새로 요청한다.
+    PageCount();
+  }, [currentPage]);
+
+  const handleChangePage = async (index: number) => {
+    setCurrentPage(index);
+  };
+  return (
+    <Div>
+      <button className="arrowButton">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-chevron-double-left"
+          viewBox="0 0 16 16"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.354 1.646a.5.5 0 0 1 0 .708L2.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"
+          />
+          <path
+            fillRule="evenodd"
+            d="M12.354 1.646a.5.5 0 0 1 0 .708L6.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"
+          />
+        </svg>
+      </button>
+      <button className="arrowButton">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-chevron-left"
+          viewBox="0 0 16 16"
+        >
+          <path
+            fillRule="evenodd"
+            d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"
+          />
+        </svg>
+      </button>
+      <Ul>
+        {pageCount.map((item, index) => {
+          return (
+            <li key={index}>
+              <PageButton
+                className={item === currentPage ? "Countselected" : ""}
+                onClick={() => handleChangePage(item)}
+              >
+                {item}
+              </PageButton>
+            </li>
+          );
+        })}
+      </Ul>
+      <button className="arrowButton">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-chevron-right"
+          viewBox="0 0 16 16"
+        >
+          <path
+            fillRule="evenodd"
+            d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
+          />
+        </svg>
+      </button>
+      <button className="arrowButton">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-chevron-double-right"
+          viewBox="0 0 16 16"
+        >
+          <path
+            fillRule="evenodd"
+            d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708"
+          />
+          <path
+            fillRule="evenodd"
+            d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708"
+          />
+        </svg>
+      </button>
+    </Div>
+  );
+}

--- a/frontend/src/components/common/PageCountUI.tsx
+++ b/frontend/src/components/common/PageCountUI.tsx
@@ -1,5 +1,5 @@
 import { GetPageCount } from "@/api/postApi";
-import React, { SetStateAction, useEffect, useState } from "react";
+import React, { SetStateAction, useEffect } from "react";
 import styled from "styled-components";
 import { FormData } from "@/types/forms";
 import { ReservationMyListStore } from "@/store/userStore";
@@ -15,11 +15,11 @@ const Div = styled.div`
     border: none;
     background-color: transparent;
     color: #888888;
-    width: 25px;
-    height: 25px;
+    width: 35px;
+    height: 35px;
     svg {
-      width: 20px;
-      height: 20px;
+      width: 35px;
+      height: 35px;
     }
 
     &:hover {
@@ -85,9 +85,28 @@ export default function PageCountUI({
   const handleChangePage = async (index: number) => {
     setCurrentPage(index);
   };
+
+  const handleDown = () => {
+    if (currentPage === 1) return;
+    setCurrentPage(currentPage - 1);
+  };
+
+  const handleUp = () => {
+    const Maxlength = pageCount.length;
+    if (currentPage === Maxlength) return;
+    setCurrentPage(currentPage + 1);
+  };
+
+  const handleStart = () => {
+    setCurrentPage(1);
+  };
+  const handleEnd = () => {
+    const Maxlength = pageCount.length;
+    setCurrentPage(Maxlength);
+  };
   return (
     <Div>
-      <button className="arrowButton">
+      <button className="arrowButton" onClick={handleStart}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -106,7 +125,7 @@ export default function PageCountUI({
           />
         </svg>
       </button>
-      <button className="arrowButton">
+      <button className="arrowButton" onClick={handleDown}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -135,7 +154,7 @@ export default function PageCountUI({
           );
         })}
       </Ul>
-      <button className="arrowButton">
+      <button className="arrowButton" onClick={handleUp}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -150,7 +169,7 @@ export default function PageCountUI({
           />
         </svg>
       </button>
-      <button className="arrowButton">
+      <button className="arrowButton" onClick={handleEnd}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"

--- a/frontend/src/components/pages/Client/About&Office/ImgMovBtn.tsx
+++ b/frontend/src/components/pages/Client/About&Office/ImgMovBtn.tsx
@@ -69,7 +69,7 @@ export default function ImgMovBtn({ direction, onClick }: ImgMovBtnProps) {
             viewBox="0 0 16 16"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"
             />
           </svg>
@@ -89,7 +89,7 @@ export default function ImgMovBtn({ direction, onClick }: ImgMovBtnProps) {
             viewBox="0 0 16 16"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
             />
           </svg>
@@ -108,7 +108,7 @@ export default function ImgMovBtn({ direction, onClick }: ImgMovBtnProps) {
             viewBox="0 0 16 16"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"
             />
           </svg>
@@ -127,7 +127,7 @@ export default function ImgMovBtn({ direction, onClick }: ImgMovBtnProps) {
             viewBox="0 0 16 16"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
             />
           </svg>

--- a/frontend/src/components/pages/Client/About&Office/Modal/ImgListItem.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/ImgListItem.tsx
@@ -29,7 +29,7 @@ export default function ImgListItem({
         viewBox="0 0 16 16"
       >
         <path
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"
         />
       </svg>

--- a/frontend/src/components/pages/Client/About&Office/Modal/PreviewImgList.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/PreviewImgList.tsx
@@ -87,7 +87,7 @@ export default function PreviewImgList({
         viewBox="0 0 16 16"
       >
         <path
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"
         />
       </svg>

--- a/frontend/src/components/pages/Client/About&Office/ViewBox.tsx
+++ b/frontend/src/components/pages/Client/About&Office/ViewBox.tsx
@@ -40,7 +40,6 @@ export default function ViewBox() {
       } else if (location.pathname.includes("/office")) {
         res = await GetOfficeWrite();
       }
-      console.log(res);
       setAboutTextData(res.result.content);
     };
     fetchText();
@@ -50,7 +49,6 @@ export default function ViewBox() {
     setEditSection(false);
     setContent(aboutTextData);
   };
-  console.log(aboutTextData);
   return (
     <ViewSection>
       <EditButton

--- a/frontend/src/components/pages/Client/LayoutPage.tsx
+++ b/frontend/src/components/pages/Client/LayoutPage.tsx
@@ -9,6 +9,7 @@ const Layout = styled.div`
   flex-direction: column;
   align-items: center;
   overflow: hidden;
+  min-height: 100vh;
 `;
 
 const Header = styled.header`
@@ -26,6 +27,7 @@ const LogoDiv = styled.div`
 const Main = styled.main`
   width: 100%;
   max-width: 1200px;
+  flex-grow: 1;
 `;
 
 export default function LayoutPage() {

--- a/frontend/src/components/pages/Client/NaverLogin.tsx
+++ b/frontend/src/components/pages/Client/NaverLogin.tsx
@@ -12,11 +12,9 @@ export default function NaverLogin() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log(code);
     if (code) {
       postLogin({ code, state })
         .then((userData) => {
-          console.log("유저 데이터", userData.user.name);
           setIsLogin(true);
           setUserName(userData.user.name);
           // 로그인 완료 시 다시 페이지 이동

--- a/frontend/src/components/pages/Client/Reservation/ButtonWrap.tsx
+++ b/frontend/src/components/pages/Client/Reservation/ButtonWrap.tsx
@@ -1,3 +1,6 @@
+import { GetReservation, PostDeleteReservation } from "@/api/postApi";
+import { ReservationMyListStore } from "@/store/userStore";
+import { TableFormProps } from "@/types/forms";
 import React from "react";
 import styled from "styled-components";
 
@@ -22,12 +25,40 @@ const DeleteButton = styled(Button)`
   color: white;
 `;
 
-export default function ButtonWrap() {
+export default function ButtonWrap({ form, setForm }: TableFormProps) {
+  const { checkedList, setCheckedList } = ReservationMyListStore();
+  const handleChecked = () => {
+    const newArr = new Array(checkedList.length).fill(true);
+    setCheckedList(newArr);
+  };
+
+  const handleUnChecked = () => {
+    const newArr = new Array(checkedList.length).fill(false);
+    setCheckedList(newArr);
+  };
+
+  const handleDelete = async () => {
+    // 삭제할 데이터의 id 값을 배열로 모은다.
+    const deleteArray: number[] = [];
+    checkedList.forEach((item, index) => {
+      if (item === false) return;
+      deleteArray.push(form[index].id);
+    });
+
+    const res = await PostDeleteReservation(deleteArray);
+    const result = await GetReservation();
+    setForm(result.result);
+
+    if (res.message === "삭제 성공") {
+      alert("삭제 성공");
+    }
+  };
+
   return (
     <Div>
-      <Button>전체선택</Button>
-      <Button>선택해제</Button>
-      <DeleteButton>삭제</DeleteButton>
+      <Button onClick={handleChecked}>전체선택</Button>
+      <Button onClick={handleUnChecked}>선택해제</Button>
+      <DeleteButton onClick={handleDelete}>삭제</DeleteButton>
     </Div>
   );
 }

--- a/frontend/src/components/pages/Client/Reservation/ButtonWrap.tsx
+++ b/frontend/src/components/pages/Client/Reservation/ButtonWrap.tsx
@@ -1,7 +1,11 @@
-import { GetReservation, PostDeleteReservation } from "@/api/postApi";
+import {
+  GetPageCount,
+  GetReservation,
+  PostDeleteReservation,
+} from "@/api/postApi";
 import { ReservationMyListStore } from "@/store/userStore";
 import { TableFormProps } from "@/types/forms";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 const Div = styled.div`
@@ -27,6 +31,21 @@ const DeleteButton = styled(Button)`
 
 export default function ButtonWrap({ form, setForm }: TableFormProps) {
   const { checkedList, setCheckedList } = ReservationMyListStore();
+  const { pageCount, setPageCount, currentPage, setCurrentPage } =
+    ReservationMyListStore();
+
+  // 페이지가 변경되면 (항목을 지워서 1로 돌아갔으면) 새로받아오기
+  useEffect(() => {
+    // 현재 페이지 값이 바뀐게 확인되어야만 데이터를 새로 요청한다.
+    PageCount();
+  }, [currentPage]);
+
+  const PageCount = async () => {
+    const res = await GetPageCount("mySubmitList", currentPage);
+    setPageCount(Array.from({ length: res.result }, (_, i) => i + 1));
+    setForm(res.TotalItems);
+  };
+
   const handleChecked = () => {
     const newArr = new Array(checkedList.length).fill(true);
     setCheckedList(newArr);
@@ -46,8 +65,9 @@ export default function ButtonWrap({ form, setForm }: TableFormProps) {
     });
 
     const res = await PostDeleteReservation(deleteArray);
-    const result = await GetReservation();
-    setForm(result.result);
+    // const result = await GetReservation();
+    // setForm(result.result);
+    setCurrentPage(1); // 지웠으면 페이지 1로 돌아가기
 
     if (res.message === "삭제 성공") {
       alert("삭제 성공");

--- a/frontend/src/components/pages/Client/Reservation/MyListSection.tsx
+++ b/frontend/src/components/pages/Client/Reservation/MyListSection.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from "react";
+import React, { SetStateAction, useState } from "react";
 import SearchBar from "./SearchBar";
 import ButtonWrap from "./ButtonWrap";
 import { FormData } from "@/types/forms";
 import TableForm from "./TableForm";
+interface MyListSectionProps {
+  form: FormData[];
+  setForm: React.Dispatch<SetStateAction<FormData[]>>;
+}
 
-export default function MyListSection() {
-  const [form, setForm] = useState<FormData[]>([]);
-
+export default function MyListSection({ form, setForm }: MyListSectionProps) {
   return (
     <section>
       <ButtonWrap form={form} setForm={setForm} />

--- a/frontend/src/components/pages/Client/Reservation/MyListSection.tsx
+++ b/frontend/src/components/pages/Client/Reservation/MyListSection.tsx
@@ -1,13 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import SearchBar from "./SearchBar";
 import ButtonWrap from "./ButtonWrap";
+import { FormData } from "@/types/forms";
 import TableForm from "./TableForm";
 
 export default function MyListSection() {
+  const [form, setForm] = useState<FormData[]>([]);
+
   return (
     <section>
-      <ButtonWrap />
-      <TableForm />
+      <ButtonWrap form={form} setForm={setForm} />
+      <TableForm form={form} setForm={setForm} />
     </section>
   );
 }

--- a/frontend/src/components/pages/Client/Reservation/TableForm.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableForm.tsx
@@ -7,6 +7,7 @@ import { ReservationMyListStore } from "@/store/userStore";
 
 const Table = styled.table`
   width: 100%;
+  /* table-layout: fixed; */
 
   thead {
     border-top: 1px solid #111111;
@@ -37,13 +38,6 @@ export default function TableForm({ form, setForm }: TableFormProps) {
     setCheckedList(new Array(form.length).fill(false));
   }, [form]);
 
-  // useEffect(() => {
-  //   const fetchSubmitData = async () => {
-  //     const res = await GetReservation();
-  //     setForm(res.result);
-  //   };
-  //   fetchSubmitData();
-  // }, []);
   return (
     <Table>
       <thead>

--- a/frontend/src/components/pages/Client/Reservation/TableForm.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import TableListItem from "./TableListItem";
 import { GetReservation } from "@/api/postApi";
 import { TableFormProps } from "@/types/forms";
@@ -7,13 +7,23 @@ import { ReservationMyListStore } from "@/store/userStore";
 
 const Table = styled.table`
   width: 100%;
+
+  thead {
+    border-top: 1px solid #111111;
+    border-bottom: 1px solid #111111;
+  }
+  tbody {
+    border-bottom: 1px solid #111111;
+    tr:first-child {
+      border-top: none;
+    }
+  }
 `;
 
 const TableRow = styled.tr`
   font-size: 20px;
   font-weight: 600;
-  border-top: 1px solid #111111;
-  border-bottom: 1px solid #111111;
+
   th {
     padding: 20px 0;
   }
@@ -27,13 +37,13 @@ export default function TableForm({ form, setForm }: TableFormProps) {
     setCheckedList(new Array(form.length).fill(false));
   }, [form]);
 
-  useEffect(() => {
-    const fetchSubmitData = async () => {
-      const res = await GetReservation();
-      setForm(res.result);
-    };
-    fetchSubmitData();
-  }, []);
+  // useEffect(() => {
+  //   const fetchSubmitData = async () => {
+  //     const res = await GetReservation();
+  //     setForm(res.result);
+  //   };
+  //   fetchSubmitData();
+  // }, []);
   return (
     <Table>
       <thead>

--- a/frontend/src/components/pages/Client/Reservation/TableForm.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableForm.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import TableListItem from "./TableListItem";
 import { GetReservation } from "@/api/postApi";
-import { FormData } from "@/types/forms";
+import { TableFormProps } from "@/types/forms";
 import styled from "styled-components";
+import { ReservationMyListStore } from "@/store/userStore";
 
 const Table = styled.table`
   width: 100%;
@@ -16,25 +17,19 @@ const TableRow = styled.tr`
   th {
     padding: 20px 0;
   }
-  .select-th {
-  }
-  .number-th {
-  }
-  .name-th {
-  }
-  .date-th {
-  }
-  .comfirm-th {
-  }
 `;
 
-export default function TableForm() {
-  const [form, setForm] = useState<FormData[]>([]);
+export default function TableForm({ form, setForm }: TableFormProps) {
+  const { setCheckedList } = ReservationMyListStore();
+
+  // 데이터가 들어오면 개수를 파악해서 체크상태 유동적으로 설정
+  useEffect(() => {
+    setCheckedList(new Array(form.length).fill(false));
+  }, [form]);
 
   useEffect(() => {
     const fetchSubmitData = async () => {
       const res = await GetReservation();
-      console.log(res.result);
       setForm(res.result);
     };
     fetchSubmitData();
@@ -43,11 +38,11 @@ export default function TableForm() {
     <Table>
       <thead>
         <TableRow>
-          <th className="select-th">선택</th>
-          <th className="number-th">번호</th>
-          <th className="name-th">신청인</th>
-          <th className="date-th">등록일</th>
-          <th className="comfirm-th">확인여부</th>
+          <th>선택</th>
+          <th>번호</th>
+          <th>신청인</th>
+          <th>등록일</th>
+          <th>확인여부</th>
         </TableRow>
       </thead>
       <tbody>

--- a/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
@@ -10,6 +10,7 @@ interface TableListItemProps {
 
 const TableRow = styled.tr<{ $form: boolean }>`
   border-top: 1px solid #dddddd;
+
   td {
     padding: 20px 0;
   }
@@ -32,8 +33,9 @@ export default function TableListItem({ form, orderNum }: TableListItemProps) {
   const date = String(dateObj.getDate()).padStart(2, "0");
 
   // 목차 시작 인덱스를 현재 페이지 기반으로 재 계산
+  const limit = 1;
   useEffect(() => {
-    setStartIndex((currentPage - 1) * 2 + 1);
+    setStartIndex((currentPage - 1) * limit + 1);
   }, [currentPage]);
 
   const handleChange = () => {

--- a/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
@@ -1,3 +1,4 @@
+import { ReservationMyListStore } from "@/store/userStore";
 import { FormData } from "@/types/forms";
 import React from "react";
 import styled from "styled-components";
@@ -23,16 +24,25 @@ const TableRow = styled.tr<{ $form: boolean }>`
 `;
 
 export default function TableListItem({ form, orderNum }: TableListItemProps) {
+  const { checkedList, setCheckedList } = ReservationMyListStore();
   const dateObj = new Date(form.createdAt);
   const year = dateObj.getFullYear();
   const month = String(dateObj.getMonth() + 1).padStart(2, "0");
   const date = String(dateObj.getDate()).padStart(2, "0");
-  console.log(`${year}.${month}.${date}`);
-  console.log(form);
+
+  const handleChange = () => {
+    const newArray = [...checkedList];
+    newArray[orderNum] = !newArray[orderNum];
+    setCheckedList(newArray);
+  };
   return (
     <TableRow $form={form.is_confirmed}>
       <td>
-        <input type="checkbox" />
+        <input
+          type="checkbox"
+          checked={checkedList[orderNum] || false}
+          onChange={handleChange}
+        />
       </td>
       <td>{orderNum + 1}</td>
       <td>{form.userId}</td>

--- a/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
+++ b/frontend/src/components/pages/Client/Reservation/TableListItem.tsx
@@ -1,6 +1,6 @@
 import { ReservationMyListStore } from "@/store/userStore";
 import { FormData } from "@/types/forms";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 interface TableListItemProps {
@@ -9,9 +9,9 @@ interface TableListItemProps {
 }
 
 const TableRow = styled.tr<{ $form: boolean }>`
+  border-top: 1px solid #dddddd;
   td {
     padding: 20px 0;
-    border-top: 1px solid #dddddd;
   }
 
   input {
@@ -24,11 +24,17 @@ const TableRow = styled.tr<{ $form: boolean }>`
 `;
 
 export default function TableListItem({ form, orderNum }: TableListItemProps) {
-  const { checkedList, setCheckedList } = ReservationMyListStore();
+  const { checkedList, setCheckedList, currentPage } = ReservationMyListStore();
+  const [startIndex, setStartIndex] = useState<number>(0);
   const dateObj = new Date(form.createdAt);
   const year = dateObj.getFullYear();
   const month = String(dateObj.getMonth() + 1).padStart(2, "0");
   const date = String(dateObj.getDate()).padStart(2, "0");
+
+  // 목차 시작 인덱스를 현재 페이지 기반으로 재 계산
+  useEffect(() => {
+    setStartIndex((currentPage - 1) * 2 + 1);
+  }, [currentPage]);
 
   const handleChange = () => {
     const newArray = [...checkedList];
@@ -44,8 +50,8 @@ export default function TableListItem({ form, orderNum }: TableListItemProps) {
           onChange={handleChange}
         />
       </td>
-      <td>{orderNum + 1}</td>
-      <td>{form.userId}</td>
+      <td>{startIndex + orderNum}</td>
+      <td>{form.name}</td>
       <td>{`${year}.${month}.${date}`}</td>
       <td className="td_confirmed">
         {form.is_confirmed ? "확인완료" : "미확인"}

--- a/frontend/src/components/pages/Client/ReservationPage.tsx
+++ b/frontend/src/components/pages/Client/ReservationPage.tsx
@@ -29,7 +29,7 @@ export default function ReservationPage() {
         title="예약상담"
         root="예약상담"
         root1Url="/reservation"
-        root2="예약상담"
+        root2={selectTab ? "예약상담" : "나의 문의/신청내역"}
       />
       <TabSwitch
         Title1="예약상담"

--- a/frontend/src/components/pages/Client/ReservationPage.tsx
+++ b/frontend/src/components/pages/Client/ReservationPage.tsx
@@ -6,16 +6,21 @@ import { useUserStore } from "@/store/userStore";
 import { useNavigate } from "react-router-dom";
 import MyListSection from "./Reservation/MyListSection";
 import FormSection from "./Reservation/FormSection";
+import PageCountUI from "@/components/common/PageCountUI";
+import { FormData } from "@/types/forms";
 
 const Div = styled.div`
   text-align: center;
   margin-bottom: 170px;
+  display: flex;
+  flex-direction: column;
 `;
 
 export default function ReservationPage() {
   const [selectTab, setSelectTab] = useState(true);
   const { isLogin } = useUserStore();
   const navigate = useNavigate();
+  const [form, setForm] = useState<FormData[]>([]);
 
   useEffect(() => {
     if (!isLogin) {
@@ -37,7 +42,15 @@ export default function ReservationPage() {
         selectTab={selectTab}
         setSelectTab={setSelectTab}
       />
-      {selectTab ? <FormSection /> : <MyListSection />}
+      {selectTab ? (
+        <FormSection />
+      ) : (
+        <MyListSection form={form} setForm={setForm} />
+      )}
+
+      {!selectTab && (
+        <PageCountUI form={form} setForm={setForm} type={"mySubmitList"} />
+      )}
     </Div>
   );
 }

--- a/frontend/src/components/pages/Client/ReservationPage.tsx
+++ b/frontend/src/components/pages/Client/ReservationPage.tsx
@@ -2,10 +2,10 @@ import PageHeader from "@/components/common/PageHeader";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import TabSwitch from "./About&Office/TabSwitch";
-import FormSection from "./Reservation/FormSection";
 import { useUserStore } from "@/store/userStore";
 import { useNavigate } from "react-router-dom";
 import MyListSection from "./Reservation/MyListSection";
+import FormSection from "./Reservation/FormSection";
 
 const Div = styled.div`
   text-align: center;

--- a/frontend/src/components/pages/Client/main/Main.tsx
+++ b/frontend/src/components/pages/Client/main/Main.tsx
@@ -25,7 +25,6 @@ export default function Main() {
 
     try {
       const response = await postUpload(formData);
-      console.log("업로드 성공:", response.url);
     } catch (error) {
       console.error("업로드 실패", error);
     }

--- a/frontend/src/components/pages/Client/main/SectionAbout.tsx
+++ b/frontend/src/components/pages/Client/main/SectionAbout.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 
-const AboutSection = styled.section<{ imageUrl: string }>`
+const AboutSection = styled.section<{ $imageUrl: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -43,7 +43,7 @@ const AboutSection = styled.section<{ imageUrl: string }>`
     z-index: 0;
 
     background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
-      url(${(props) => props.imageUrl});
+      url(${(props) => props.$imageUrl});
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -91,7 +91,7 @@ export default function SectionAbout() {
     "https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/Layer+3.png"
   );
   return (
-    <AboutSection imageUrl={imageUrl}>
+    <AboutSection $imageUrl={imageUrl}>
       <button>
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -103,7 +103,7 @@ export default function SectionAbout() {
         >
           <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z" />
           <path
-            fill-rule="evenodd"
+            fillRule="evenodd"
             d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"
           />
         </svg>

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -162,11 +162,19 @@ export const ReservationInputStore = create<ReservationInputProps>((set) => ({
 
 interface ReservationMyListStoreProps {
   checkedList: boolean[];
+  pageCount: number[];
+  currentPage: number;
   setCheckedList: (state: boolean[]) => void;
+  setPageCount: (num: number[]) => void;
+  setCurrentPage: (num: number) => void;
 }
 export const ReservationMyListStore = create<ReservationMyListStoreProps>(
   (set) => ({
     checkedList: [],
+    pageCount: [],
+    currentPage: 1,
     setCheckedList: (state: boolean[]) => set({ checkedList: state }),
+    setPageCount: (num: number[]) => set({ pageCount: num }),
+    setCurrentPage: (num: number) => set({ currentPage: num }),
   })
 );

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -159,3 +159,14 @@ export const ReservationInputStore = create<ReservationInputProps>((set) => ({
     });
   },
 }));
+
+interface ReservationMyListStoreProps {
+  checkedList: boolean[];
+  setCheckedList: (state: boolean[]) => void;
+}
+export const ReservationMyListStore = create<ReservationMyListStoreProps>(
+  (set) => ({
+    checkedList: [],
+    setCheckedList: (state: boolean[]) => set({ checkedList: state }),
+  })
+);

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -1,3 +1,5 @@
+import { SetStateAction } from "react";
+
 type FileItem = {
   id: string;
   file: File;
@@ -21,4 +23,8 @@ export interface FormData {
   file: string; // stringified array, parse on use
   createdAt: string;
   updatedAt: string;
+}
+export interface TableFormProps {
+  form: FormData[];
+  setForm: React.Dispatch<SetStateAction<FormData[]>>;
 }


### PR DESCRIPTION

<img width="1333" alt="스크린샷 2025-05-23 오전 12 38 28" src="https://github.com/user-attachments/assets/4eac298c-1379-4b6b-874e-b964eb6fc23c" />

##  구현한 기능

###  신청 현황 리스트
- 내가 신청했던 데이터 리스트 출력
- 전체 선택 / 전체 해제 기능 구현
- 선택 항목 삭제 기능 및 삭제 후 API 연동을 통한 데이터 최신화

###  페이지네이션
- 데이터 총 개수를 기반으로 총 페이지 수 계산
- 페이지당 10개 항목 기준 `limit`과 `offset`을 활용한 데이터 분할 요청
- 초기 로딩 시 1페이지 데이터만 요청해 렌더링
- 페이지 버튼 클릭 시 해당 페이지 번호를 기반으로 offset 재계산 후 재요청
- 전체 페이지 수에 맞춰 페이지 버튼 UI 동적 생성 및 현재 페이지 강조 처리

### 상태 관리
- 현재 페이지 상태를 Zustand로 관리
- `useEffect`로 `currentPage` 상태가 변경될 때마다 데이터 자동 요청 처리

---

## 기타 참고 사항

- 페이지 이동마다 필요한 데이터만 요청하여 전체 데이터를 불필요하게 불러오지 않음
- 선택, 삭제, 페이지 전환 등 모든 동작에 상태 연동 및 최신화 로직 반영