### PR TITLE
Dev

### DIFF
--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -520,7 +520,7 @@ exports.GetPageCount = async (req, res) => {
   const token = req.cookies.token;
   // 10개로 바꾸기
   // 한페이지에 받아올 아이템 수
-  const limit = type === "GalleryImage" ? 20 : 10;
+  const limit = 10;
 
   // 시작 인덱스 구하기
   const startIndex = (page - 1) * limit;
@@ -562,14 +562,13 @@ exports.GetPageCount = async (req, res) => {
         });
         break;
 
-      case "GalleryImage":
-        result = await GalleryImage.count();
-        TotalItems = await GalleryImage.findAll({
-          limit: limit,
-          offset: startIndex,
-          // order: [["created_at", "DESC"]],
-        });
-        break;
+      // case "GalleryImage":
+      //   result = await GalleryImage.count();
+      //   TotalItems = await GalleryImage.findAll({
+      //     limit: limit,
+      //     offset: startIndex,
+      //   });
+      //   break;
 
       default:
         return res.status(400).json({ message: "유효하지 않은 type" });
@@ -602,7 +601,6 @@ exports.PostChangeState = async (req, res) => {
 exports.PutUpdateConfirm = async (req, res) => {
   const ids = req.body.ids;
   try {
-    console.log(ids); // [ 21, 20 ]
     const response = await ReservationSubmit.update(
       { is_confirmed: true },
       { where: { id: ids } }
@@ -956,6 +954,39 @@ exports.GetMainAbout = async (req, res) => {
       where: { id: 1 },
     });
     return res.status(200).json({ result: result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "답변 불러오기 실패(서버)" });
+  }
+};
+
+exports.GetMainGallery = async (req, res) => {
+  try {
+    const count = await GalleryImage.count();
+    if (count === 0) {
+      return res.status(200).json({ success: false }); // 불러올 사진이 없습니다.
+    }
+    const result = await GalleryImage.findAll({
+      limit: 8,
+      offset: 0,
+      order: sequelize.literal("RAND()"),
+      // order: [["created_at", "DESC"]],
+    });
+    return res.status(200).json({ success: true, result: result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "답변 불러오기 실패(서버)" });
+  }
+};
+
+exports.GetGalleryPage = async (req, res) => {
+  try {
+    const count = await GalleryImage.count();
+    if (count === 0) {
+      return res.status(200).json({ success: false }); // 불러올 사진이 없습니다.
+    }
+    const result = await GalleryImage.findAll({});
+    return res.status(200).json({ success: true, result: result });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "답변 불러오기 실패(서버)" });

--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -860,7 +860,7 @@ exports.PostGalleryImgUpload = [
     }
   },
 ];
-exports.PostGalleryImgEdit = async (req, res) => {
+exports.EditGalleryImgEdit = async (req, res) => {
   const newArray = req.body;
   const tx = await sequelize.transaction();
   try {

--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -702,13 +702,36 @@ exports.GetQuestion = async (req, res) => {
 exports.GetAnswer = async (req, res) => {
   const postId = req.params.id;
   try {
-    const result = await QuestionSubmit.findOne({
-      where: { id: postId },
-      include: [{ model: Answer }],
+    const result = await Answer.findOne({
+      where: { question_id: postId },
     });
     return res.status(200).json({ result: result });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "질문 불러오기 실패(서버)" });
+  }
+};
+
+exports.PostAnswerSubmit = async (req, res) => {
+  const postId = req.params.id;
+  const message = req.body.message;
+  const data = {
+    question_id: Number(postId),
+    content: message,
+  };
+  try {
+    console.log(postId, message);
+    const prevData = await Answer.findOne({ where: { question_id: postId } });
+    let result;
+    if (prevData) {
+      await Answer.update(data, { where: { question_id: postId } });
+      result = await Answer.findOne({ where: { question_id: postId } });
+    } else {
+      result = await Answer.create(data);
+    }
+    return res.status(200).json({ success: true, result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "답변 등록하기 실패(서버)" });
   }
 };

--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -605,7 +605,6 @@ exports.PutUpdateConfirm = async (req, res) => {
 exports.PutUnUpdateConfirm = async (req, res) => {
   const ids = req.body.ids;
   try {
-    console.log(ids); // [ 21, 20 ]
     const response = await ReservationSubmit.update(
       { is_confirmed: false },
       { where: { id: ids } }
@@ -674,3 +673,17 @@ exports.PostQuestionSubmit = [
     }
   },
 ];
+
+exports.PostMatchPassword = async (req, res) => {
+  // 서버에서 게시글 불러와서 비밀번호가 같은지 확인
+  const password = req.body.password;
+  const postId = req.body.postId;
+  try {
+    const response = await QuestionSubmit.findOne({ where: { id: postId } });
+    const result = response.privatePWD === password ? true : false;
+    return res.status(200).json({ match: result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "비밀번호 확인 실패(서버)" });
+  }
+};

--- a/backend/controllers/Cmain.js
+++ b/backend/controllers/Cmain.js
@@ -10,6 +10,7 @@ const {
   ReservationSubmit,
   Users,
   QuestionSubmit,
+  Answer,
 } = require("../models");
 const { sequelize } = require("../models");
 
@@ -685,5 +686,29 @@ exports.PostMatchPassword = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "비밀번호 확인 실패(서버)" });
+  }
+};
+
+exports.GetQuestion = async (req, res) => {
+  const postId = req.params.id;
+  try {
+    const result = await QuestionSubmit.findOne({ where: { id: postId } });
+    return res.status(200).json({ result: result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "질문 불러오기 실패(서버)" });
+  }
+};
+exports.GetAnswer = async (req, res) => {
+  const postId = req.params.id;
+  try {
+    const result = await QuestionSubmit.findOne({
+      where: { id: postId },
+      include: [{ model: Answer }],
+    });
+    return res.status(200).json({ result: result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "질문 불러오기 실패(서버)" });
   }
 };

--- a/backend/models/Answer.js
+++ b/backend/models/Answer.js
@@ -1,0 +1,38 @@
+module.exports = (sequelize, DataTypes) => {
+  const Answer = sequelize.define(
+    "Answer",
+    {
+      id: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      question_id: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        references: {
+          model: "questionSubmit",
+          key: "id",
+        },
+        onDelete: "CASCADE",
+      },
+      content: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: "answer",
+      timestamps: true,
+    }
+  );
+
+  Answer.associate = (models) => {
+    Answer.belongsTo(models.QuestionSubmit, {
+      foreignKey: "question_id",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return Answer;
+};

--- a/backend/models/GalleryImage.js
+++ b/backend/models/GalleryImage.js
@@ -1,0 +1,30 @@
+module.exports = (sequelize, DataTypes) => {
+  const GalleryImage = sequelize.define(
+    "GalleryImage",
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      image_url: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      tableName: "galleryImages",
+      timestamps: false,
+    }
+  );
+
+  return GalleryImage;
+};

--- a/backend/models/MainPage.js
+++ b/backend/models/MainPage.js
@@ -1,0 +1,40 @@
+const { DataTypes } = require("sequelize");
+
+module.exports = (sequelize, DataTypes) => {
+  const MainPage = sequelize.define(
+    "MainPage",
+    {
+      id: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      title_main: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "해외 의대 전문 유학원",
+      },
+      title_sub: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "드림유학원, 당신의 글로벌 미래를 응원합니다.",
+      },
+      content: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+        defaultValue: "2020 ~ 2025 우즈베키스탄 의대 전체 수속 학생수 1위",
+      },
+      image_url: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: "defaultBanner.png",
+      },
+    },
+    {
+      tableName: "mainPage",
+      timestamps: false,
+    }
+  );
+
+  return MainPage;
+};

--- a/backend/models/QuestionSubmit.js
+++ b/backend/models/QuestionSubmit.js
@@ -50,5 +50,12 @@ module.exports = (sequelize, DataTypes) => {
     }
   );
 
+  QuestionSubmit.associate = (models) => {
+    QuestionSubmit.hasOne(models.Answer, {
+      foreignKey: "question_id",
+      onDelete: "CASCADE",
+    });
+  };
+
   return QuestionSubmit;
 };

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -37,6 +37,13 @@ fs.readdirSync(__dirname)
     db[model.name] = model;
   });
 
+// ✅ 여기서 각 모델의 associate 메서드를 호출해 모델 간 관계를 연결
+Object.keys(db).forEach((modelName) => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
 

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -35,6 +35,8 @@ const {
   GetGalleryImgUpload,
   PostGalleryImgUpload,
   EditGalleryImgEdit,
+  PostMainPage,
+  GetMainAbout,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -69,5 +71,7 @@ router.delete("/Question/delete/:id", DeleteQuestion);
 router.get("/gallery/imgGet", GetGalleryImgUpload);
 router.post("/gallery/imgUpdate", PostGalleryImgUpload);
 router.post("/gallery/imgEdit", EditGalleryImgEdit);
+router.post("/Main/AboutData", PostMainPage);
+router.get("/Main/GetAboutData", GetMainAbout);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -30,6 +30,8 @@ const {
   GetQuestion,
   GetAnswer,
   PostAnswerSubmit,
+  DeleteQuestion,
+  GetSearch,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -56,8 +58,10 @@ router.put("/AdminReservation/confirm", PutUpdateConfirm);
 router.put("/AdminReservation/Unconfirm", PutUnUpdateConfirm);
 router.post("/Question/submit", PostQuestionSubmit);
 router.post("/Question/Password", PostMatchPassword);
+router.get("/Question/search", GetSearch);
 router.get("/Question/:id", GetQuestion);
 router.get("/Answer/:id", GetAnswer);
 router.post("/Answer/Submit/:id", PostAnswerSubmit);
+router.delete("/Question/delete/:id", DeleteQuestion);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -34,7 +34,7 @@ const {
   GetSearch,
   GetGalleryImgUpload,
   PostGalleryImgUpload,
-  PostGalleryImgEdit,
+  EditGalleryImgEdit,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -68,6 +68,6 @@ router.post("/Answer/Submit/:id", PostAnswerSubmit);
 router.delete("/Question/delete/:id", DeleteQuestion);
 router.get("/gallery/imgGet", GetGalleryImgUpload);
 router.post("/gallery/imgUpdate", PostGalleryImgUpload);
-router.post("/gallery/imgEdit", PostGalleryImgEdit);
+router.post("/gallery/imgEdit", EditGalleryImgEdit);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -28,6 +28,7 @@ const {
   PostQuestionSubmit,
   PostMatchPassword,
   GetQuestion,
+  GetAnswer,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -55,5 +56,6 @@ router.put("/AdminReservation/Unconfirm", PutUnUpdateConfirm);
 router.post("/Question/submit", PostQuestionSubmit);
 router.post("/Question/Password", PostMatchPassword);
 router.get("/Question/:id", GetQuestion);
+router.get("/Answer/:id", GetAnswer);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -32,6 +32,9 @@ const {
   PostAnswerSubmit,
   DeleteQuestion,
   GetSearch,
+  GetGalleryImgUpload,
+  PostGalleryImgUpload,
+  PostGalleryImgEdit,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -63,5 +66,8 @@ router.get("/Question/:id", GetQuestion);
 router.get("/Answer/:id", GetAnswer);
 router.post("/Answer/Submit/:id", PostAnswerSubmit);
 router.delete("/Question/delete/:id", DeleteQuestion);
+router.get("/gallery/imgGet", GetGalleryImgUpload);
+router.post("/gallery/imgUpdate", PostGalleryImgUpload);
+router.post("/gallery/imgEdit", PostGalleryImgEdit);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -29,6 +29,7 @@ const {
   PostMatchPassword,
   GetQuestion,
   GetAnswer,
+  PostAnswerSubmit,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -57,5 +58,6 @@ router.post("/Question/submit", PostQuestionSubmit);
 router.post("/Question/Password", PostMatchPassword);
 router.get("/Question/:id", GetQuestion);
 router.get("/Answer/:id", GetAnswer);
+router.post("/Answer/Submit/:id", PostAnswerSubmit);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -26,6 +26,8 @@ const {
   PutUpdateConfirm,
   PutUnUpdateConfirm,
   PostQuestionSubmit,
+  PostMatchPassword,
+  GetQuestion,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -51,5 +53,7 @@ router.post("/AdminReservation/ChangeState", PostChangeState);
 router.put("/AdminReservation/confirm", PutUpdateConfirm);
 router.put("/AdminReservation/Unconfirm", PutUnUpdateConfirm);
 router.post("/Question/submit", PostQuestionSubmit);
+router.post("/Question/Password", PostMatchPassword);
+router.get("/Question/:id", GetQuestion);
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -37,6 +37,8 @@ const {
   EditGalleryImgEdit,
   PostMainPage,
   GetMainAbout,
+  GetMainGallery,
+  GetGalleryPage,
 } = require("../controllers/Cmain");
 
 router.get("/user/getInfo", getUserInfo);
@@ -71,7 +73,9 @@ router.delete("/Question/delete/:id", DeleteQuestion);
 router.get("/gallery/imgGet", GetGalleryImgUpload);
 router.post("/gallery/imgUpdate", PostGalleryImgUpload);
 router.post("/gallery/imgEdit", EditGalleryImgEdit);
+router.get("/gallery/GetGalleryPage", GetGalleryPage);
 router.post("/Main/AboutData", PostMainPage);
 router.get("/Main/GetAboutData", GetMainAbout);
+router.get("/Main/GetGalleryImg", GetMainGallery);
 
 module.exports = router;

--- a/frontend/public/right.svg
+++ b/frontend/public/right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+</svg>

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -277,9 +277,18 @@ export const PostMatchPassword = async (password: string, postId: number) => {
 
 export const GetQuestion = async (id: string) => {
   try {
-    const response = await API.get(`api/Question/:id`);
+    const response = await API.get(`api/Question/${id}`);
     return response.data;
   } catch (error) {
-    console.error("비밀번호 매치 실패", error);
+    console.error("질문 가져오기 실패", error);
+  }
+};
+
+export const GetAnswer = async (id: string) => {
+  try {
+    const response = await API.get(`api/Answer/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error("답변 가져오기 실패", error);
   }
 };

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -378,3 +378,21 @@ export const GetMainAbout = async () => {
     console.error("메인페이지 데이터 불러오기 실패", error);
   }
 };
+
+export const GetGalleryImg = async () => {
+  try {
+    const response = await API.get(`api/Main/GetGalleryImg`);
+    return response.data;
+  } catch (error) {
+    console.error("메인페이지 데이터 불러오기 실패", error);
+  }
+};
+
+export const GetGalleryPage = async () => {
+  try {
+    const response = await API.get(`api/gallery/GetGalleryPage`);
+    return response.data;
+  } catch (error) {
+    console.error("갤러리 이미지 불러오기 실패", error);
+  }
+};

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -356,3 +356,25 @@ export const EditGalleryImges = async (newArray: GallerySlide[]) => {
     console.error("Gallery 페이지 이미지 수정하기 실패", err);
   }
 };
+
+export const PostMainPage = async (formData: FormData) => {
+  try {
+    const response = await API.post(`api/Main/AboutData`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("메인페이지 데이터 전송 실패", error);
+  }
+};
+
+export const GetMainAbout = async () => {
+  try {
+    const response = await API.get(`api/Main/GetAboutData`);
+    return response.data;
+  } catch (error) {
+    console.error("메인페이지 데이터 불러오기 실패", error);
+  }
+};

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -1,3 +1,4 @@
+import { GallerySlide } from "@/types/forms";
 import axios from "axios";
 
 const API = axios.create({
@@ -322,5 +323,36 @@ export const getSearch = async (keyword: string, searchField: string) => {
     return response.data;
   } catch (error) {
     console.error("질문 삭제 실패", error);
+  }
+};
+
+export const GetGalleryImages = async () => {
+  try {
+    const response = await API.get(`api/gallery/imgGet`);
+    return response.data;
+  } catch (error) {
+    console.error("gallery 페이지 이미지 불러오기 실패", error);
+  }
+};
+
+export const PostGalleryImages = async (formData: FormData) => {
+  try {
+    const response = await API.post(`api/gallery/imgUpdate`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("gallery 페이지 이미지 전송 실패", error);
+  }
+};
+
+export const EditGalleryImges = async (newArray: GallerySlide[]) => {
+  try {
+    const response = await API.post(`/api/gallery/imgEdit`, newArray);
+    return response;
+  } catch (err) {
+    console.error("Gallery 페이지 이미지 수정하기 실패", err);
   }
 };

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -264,3 +264,22 @@ export const PostQuestion = async (formData: FormData) => {
     console.error("질문 등록 실패", error);
   }
 };
+
+export const PostMatchPassword = async (password: string, postId: number) => {
+  const data = { password: password, postId: postId };
+  try {
+    const response = await API.post(`api/Question/Password`, data);
+    return response.data;
+  } catch (error) {
+    console.error("비밀번호 매치 실패", error);
+  }
+};
+
+export const GetQuestion = async (id: string) => {
+  try {
+    const response = await API.get(`api/Question/:id`);
+    return response.data;
+  } catch (error) {
+    console.error("비밀번호 매치 실패", error);
+  }
+};

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -292,3 +292,12 @@ export const GetAnswer = async (id: string) => {
     console.error("답변 가져오기 실패", error);
   }
 };
+
+export const PostAnswerSubmit = async (id: string, message: string) => {
+  try {
+    const response = await API.post(`api/Answer/Submit/${id}`, { message });
+    return response.data;
+  } catch (error) {
+    console.error("답변 등록하기 실패", error);
+  }
+};

--- a/frontend/src/api/postApi.ts
+++ b/frontend/src/api/postApi.ts
@@ -301,3 +301,26 @@ export const PostAnswerSubmit = async (id: string, message: string) => {
     console.error("답변 등록하기 실패", error);
   }
 };
+
+export const DeleteQuestion = async (id: string) => {
+  try {
+    const response = await API.delete(`api/Question/delete/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error("질문 삭제 실패", error);
+  }
+};
+
+export const getSearch = async (keyword: string, searchField: string) => {
+  try {
+    const response = await API.get(`api/Question/search`, {
+      params: {
+        keyword: keyword,
+        searchField: searchField,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("질문 삭제 실패", error);
+  }
+};

--- a/frontend/src/components/common/ImageOverlay.tsx
+++ b/frontend/src/components/common/ImageOverlay.tsx
@@ -1,0 +1,59 @@
+import { UseModalStore } from "@/store/userStore";
+import React from "react";
+import styled from "styled-components";
+
+const Div = styled.div`
+  cursor: pointer;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #000000bf;
+  img {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    max-width: 800px;
+  }
+`;
+
+const CancleButton = styled.button`
+  width: 10vw;
+  height: 10vh;
+  background-color: transparent;
+  color: white;
+  border: none;
+  cursor: pointer;
+  position: absolute;
+  top: 5vw;
+  right: 5vh;
+
+  svg {
+    width: 30px;
+    height: 30px;
+  }
+`;
+
+export default function ImageOverlay() {
+  const { ImageSrc, setImageModal } = UseModalStore();
+  return (
+    <Div onClick={() => setImageModal(false)}>
+      <CancleButton onClick={() => setImageModal(false)}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-x-lg"
+          viewBox="0 0 16 16"
+        >
+          <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8z" />
+        </svg>
+      </CancleButton>
+      <img src={ImageSrc} alt="이미지 오버레이" />
+    </Div>
+  );
+}

--- a/frontend/src/components/common/ModalButtonBox.tsx
+++ b/frontend/src/components/common/ModalButtonBox.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { SetStateAction } from "react";
 import styled from "styled-components";
 import Button from "./Button";
 import { ControlModalStore } from "@/store/userStore";
+import { PostMatchPassword } from "@/api/postApi";
+import { useNavigate } from "react-router-dom";
 
 const ButtonBox = styled.div`
   display: flex;
@@ -16,10 +18,28 @@ const StyleButton = styled(Button)`
   font-size: 16px;
   border-radius: 8px;
 `;
-export default function ModalButtonBox() {
-  const { setViewModal } = ControlModalStore();
+type ButtonProps = {
+  password: string[];
+  setPassword: React.Dispatch<SetStateAction<string[]>>;
+};
+export default function ModalButtonBox({ password, setPassword }: ButtonProps) {
+  const { setViewModal, postId } = ControlModalStore();
   const handleHideModal = () => {
     setViewModal(false);
+  };
+  const navigate = useNavigate();
+
+  const handleSubmit = async () => {
+    if (!postId) return;
+    const Password = password.join("");
+    const res = await PostMatchPassword(Password, postId);
+    if (res.match) {
+      setViewModal(false);
+      navigate(`/questions/${postId}`);
+    } else {
+      alert("비밀번호가 일치하지 않습니다.");
+      setPassword(["", "", "", ""]);
+    }
   };
 
   return (
@@ -34,7 +54,7 @@ export default function ModalButtonBox() {
         name="입력"
         Bgcolor="green"
         TitleColor="white"
-        // onClick={handleSubmit}
+        onClick={handleSubmit}
       />
     </ButtonBox>
   );

--- a/frontend/src/components/common/ModalUI.tsx
+++ b/frontend/src/components/common/ModalUI.tsx
@@ -1,6 +1,9 @@
 import React, { useRef, useState } from "react";
 import styled from "styled-components";
 import ModalButtonBox from "./ModalButtonBox";
+import { ControlModalStore } from "@/store/userStore";
+import { PostMatchPassword } from "@/api/postApi";
+import { useNavigate } from "react-router-dom";
 
 const Div = styled.div`
   width: 370px;
@@ -77,6 +80,8 @@ const InputWrap = styled.div`
 export default function ModalUI() {
   const [password, setPassword] = useState(["", "", "", ""]);
   const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
+  const { setViewModal, postId } = ControlModalStore();
+  const navigate = useNavigate();
 
   const handleChange = (index: number, value: string) => {
     if (!/^\d?$/.test(value)) return;
@@ -89,12 +94,28 @@ export default function ModalUI() {
     }
   };
 
+  const handleSubmit = async () => {
+    if (!postId) return;
+    const Password = password.join("");
+    const res = await PostMatchPassword(Password, postId);
+    if (res.match) {
+      setViewModal(false);
+      navigate(`/questions/${postId}`);
+    } else {
+      alert("비밀번호가 일치하지 않습니다.");
+      setPassword(["", "", "", ""]);
+    }
+  };
+
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
     index: number
   ) => {
     if (e.key === "Backspace" && password[index] === "" && index > 0) {
       inputsRef.current[index - 1]?.focus();
+    }
+    if (e.key === "Enter" && index === 3) {
+      handleSubmit();
     }
   };
 
@@ -136,7 +157,7 @@ export default function ModalUI() {
           );
         })}
       </InputWrap>
-      <ModalButtonBox />
+      <ModalButtonBox password={password} setPassword={setPassword} />
     </Div>
   );
 }

--- a/frontend/src/components/common/PageCountUI.tsx
+++ b/frontend/src/components/common/PageCountUI.tsx
@@ -2,7 +2,11 @@ import { GetPageCount } from "@/api/postApi";
 import React, { SetStateAction, useEffect } from "react";
 import styled from "styled-components";
 import { FormData, QuestionData } from "@/types/forms";
-import { ReservationMyListStore, SearchStore } from "@/store/userStore";
+import {
+  ReservationMyListStore,
+  SearchStore,
+  UseModalStore,
+} from "@/store/userStore";
 const Div = styled.div`
   display: flex;
   align-items: center;
@@ -74,6 +78,7 @@ export default function PageCountUI<T>({
 }: MyListSectionProps<T>) {
   const { pageCount, setPageCount, currentPage, setCurrentPage } =
     ReservationMyListStore();
+  const { isModalOpen, setIsModalOpen } = UseModalStore();
   const { searchList, searchData } = SearchStore();
 
   const PageCount = async () => {
@@ -108,7 +113,7 @@ export default function PageCountUI<T>({
     } else {
       PageCount();
     }
-  }, [currentPage, searchList, searchData]);
+  }, [currentPage, searchList, searchData, isModalOpen]);
 
   const handleChangePage = async (index: number) => {
     setCurrentPage(index);

--- a/frontend/src/components/common/PageCountUI.tsx
+++ b/frontend/src/components/common/PageCountUI.tsx
@@ -2,7 +2,7 @@ import { GetPageCount } from "@/api/postApi";
 import React, { SetStateAction, useEffect } from "react";
 import styled from "styled-components";
 import { FormData, QuestionData } from "@/types/forms";
-import { ReservationMyListStore } from "@/store/userStore";
+import { ReservationMyListStore, SearchStore } from "@/store/userStore";
 const Div = styled.div`
   display: flex;
   align-items: center;
@@ -74,6 +74,7 @@ export default function PageCountUI<T>({
 }: MyListSectionProps<T>) {
   const { pageCount, setPageCount, currentPage, setCurrentPage } =
     ReservationMyListStore();
+  const { searchList, searchData } = SearchStore();
 
   const PageCount = async () => {
     const res = await GetPageCount(type, currentPage);
@@ -81,20 +82,33 @@ export default function PageCountUI<T>({
       console.error("데이터 결과 없음");
       return;
     }
-    console.log(res);
+
     // 결과인 숫자를 바탕으로 필요한 페이지 수만큼 배열 생성
     setPageCount(Array.from({ length: res.result }, (_, i) => i + 1));
     setForm(res.TotalItems);
   };
 
+  const SearchPageCount = async () => {
+    const limit = 10;
+    const NeedPage = Math.ceil(searchData.length / limit);
+    const offset = (currentPage - 1) * limit;
+    const sliced = searchData.slice(offset, offset + limit) as T[];
+    setPageCount(Array.from({ length: NeedPage }, (_, i) => i + 1));
+    setForm(sliced);
+  };
+
   useEffect(() => {
     setCurrentPage(1);
-  }, []);
+  }, [searchList]);
 
   useEffect(() => {
     // 현재 페이지 값이 바뀐게 확인되어야만 데이터를 새로 요청한다.
-    PageCount();
-  }, [currentPage]);
+    if (type === "SearchList") {
+      SearchPageCount();
+    } else {
+      PageCount();
+    }
+  }, [currentPage, searchList, searchData]);
 
   const handleChangePage = async (index: number) => {
     setCurrentPage(index);

--- a/frontend/src/components/common/PageCountUI.tsx
+++ b/frontend/src/components/common/PageCountUI.tsx
@@ -62,9 +62,6 @@ const PageButton = styled.button`
   cursor: pointer;
   font-size: 16px;
 `;
-//FormData[] | QuestionData[]
-// type CommonFormSetter<T> = React.Dispatch<React.SetStateAction<T[]>>;
-
 interface MyListSectionProps<T> {
   form: T[];
   setForm: React.Dispatch<React.SetStateAction<T[]>>;

--- a/frontend/src/components/pages/Client/About&Office/EditModal.tsx
+++ b/frontend/src/components/pages/Client/About&Office/EditModal.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import {
   GetAboutImages,
+  GetGalleryImages,
   GetOfficeImages,
   PostAboutImages,
 } from "../../../../api/postApi";
@@ -53,9 +54,16 @@ export default function EditModal() {
         response = await GetAboutImages();
       } else if (location.pathname.includes("/office")) {
         response = await GetOfficeImages();
+      } else if (location.pathname.includes("/gallery")) {
+        response = await GetGalleryImages();
       }
-
+      if (!response) {
+        console.log(response);
+        alert("데이터가 없습니다.");
+        return;
+      }
       setExistingImages(response.slides);
+      console.log(response.slides);
     };
     getImageFetch();
   }, [files]);

--- a/frontend/src/components/pages/Client/About&Office/ImgViewBox.tsx
+++ b/frontend/src/components/pages/Client/About&Office/ImgViewBox.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import ImgMovBtn from "./ImgMovBtn";
 import Button from "../../../common/Button";
-import { AboutAndOfficeStore, ImgPreviewStore } from "@/store/userStore";
+import { UseModalStore, ImgPreviewStore } from "@/store/userStore";
 
 const ViewBox = styled.div`
   width: 100%;
@@ -49,7 +49,7 @@ const ImgContainer = styled.div`
 export default function ImgViewBox() {
   const { imgPreview, index, imgList, setImagePreview, setIndex } =
     ImgPreviewStore();
-  const { setIsModalOpen } = AboutAndOfficeStore();
+  const { setIsModalOpen } = UseModalStore();
   const OpenModal = () => {
     setIsModalOpen(true);
   };

--- a/frontend/src/components/pages/Client/About&Office/Modal/PreviewImgList.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/PreviewImgList.tsx
@@ -8,10 +8,10 @@ interface PreviewImgListProps {
   setPrevImg: React.Dispatch<React.SetStateAction<string>>;
 }
 type Slide = {
-  created_at: string;
-  name: string;
   id: number;
+  name: string;
   image_url: string;
+  created_at: string;
   sort_order: number;
 };
 

--- a/frontend/src/components/pages/Client/About&Office/Modal/SaveImgSection.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/SaveImgSection.tsx
@@ -88,6 +88,7 @@ export default function SaveImgSection({
           >
             {files.map((file, index) => (
               <ImgListItem
+                key={index}
                 file={file}
                 index={index}
                 files={files}

--- a/frontend/src/components/pages/Client/About&Office/Modal/SwichButtons.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/SwichButtons.tsx
@@ -3,12 +3,21 @@ import styled from "styled-components";
 import Button from "../../../../common/Button";
 import {
   EditAboutImges,
+  EditGalleryImges,
   EditOfficeImges,
   PostAboutImages,
+  PostGalleryImages,
   PostOfficeImages,
 } from "../../../../../api/postApi";
-import { AboutAndOfficeStore } from "@/store/userStore";
+import { UseModalStore } from "@/store/userStore";
 import { useLocation } from "react-router-dom";
+import { GallerySlide } from "@/types/forms";
+
+interface EditAboutImgesProps {
+  image_url: string;
+  name: string;
+  sort_order: number;
+}
 
 const StyledButton = styled(Button)`
   padding: 12px 45px;
@@ -45,7 +54,7 @@ export default function SwichButtons({
   files,
   setFiles,
 }: SwitchButtonsProps) {
-  const { setIsModalOpen } = AboutAndOfficeStore();
+  const { setIsModalOpen } = UseModalStore();
   const CloseModal = () => {
     setIsModalOpen(false);
   };
@@ -62,23 +71,39 @@ export default function SwichButtons({
       await PostAboutImages(formData);
     } else if (location.pathname.includes("/office")) {
       await PostOfficeImages(formData);
+    } else if (location.pathname.includes("/gallery")) {
+      await PostGalleryImages(formData);
     }
-
+    alert("이미지 업로드가 완료되었습니다.");
     setFiles([]);
   };
 
   const handleEdit = async () => {
-    const newArray = existingImages.map((item, index) => ({
-      image_url: item.image_url,
-      name: item.name,
-      sort_order: index,
-    }));
-
-    if (location.pathname.includes("/about")) {
-      await EditAboutImges(newArray);
-    } else if (location.pathname.includes("/office")) {
-      await EditOfficeImges(newArray);
+    let newArray;
+    if (location.pathname.includes("/gallery")) {
+      newArray = existingImages.map((item, index) => ({
+        image_url: item.image_url,
+        name: item.name,
+      }));
+    } else {
+      newArray = existingImages.map((item, index) => ({
+        image_url: item.image_url,
+        name: item.name,
+        sort_order: index,
+      }));
     }
+
+    if (location.pathname.includes("/about") && "sort_order" in newArray[0]) {
+      await EditAboutImges(newArray as EditAboutImgesProps[]);
+    } else if (
+      location.pathname.includes("/office") &&
+      "sort_order" in newArray[0]
+    ) {
+      await EditOfficeImges(newArray as EditAboutImgesProps[]);
+    } else if (location.pathname.includes("/gallery")) {
+      await EditGalleryImges(newArray as GallerySlide[]);
+    }
+    alert("수정이 완료되었습니다.");
   };
   return (
     <ButtonWrap>

--- a/frontend/src/components/pages/Client/About&Office/Modal/SwichButtons.tsx
+++ b/frontend/src/components/pages/Client/About&Office/Modal/SwichButtons.tsx
@@ -9,7 +9,7 @@ import {
   PostGalleryImages,
   PostOfficeImages,
 } from "../../../../../api/postApi";
-import { UseModalStore } from "@/store/userStore";
+import { ReservationMyListStore, UseModalStore } from "@/store/userStore";
 import { useLocation } from "react-router-dom";
 import { GallerySlide } from "@/types/forms";
 
@@ -76,6 +76,7 @@ export default function SwichButtons({
     }
     alert("이미지 업로드가 완료되었습니다.");
     setFiles([]);
+    setIsModalOpen(false);
   };
 
   const handleEdit = async () => {
@@ -92,7 +93,7 @@ export default function SwichButtons({
         sort_order: index,
       }));
     }
-
+    let res;
     if (location.pathname.includes("/about") && "sort_order" in newArray[0]) {
       await EditAboutImges(newArray as EditAboutImgesProps[]);
     } else if (
@@ -101,9 +102,10 @@ export default function SwichButtons({
     ) {
       await EditOfficeImges(newArray as EditAboutImgesProps[]);
     } else if (location.pathname.includes("/gallery")) {
-      await EditGalleryImges(newArray as GallerySlide[]);
+      res = await EditGalleryImges(newArray as GallerySlide[]);
     }
     alert("수정이 완료되었습니다.");
+    setIsModalOpen(false);
   };
   return (
     <ButtonWrap>

--- a/frontend/src/components/pages/Client/AboutPage.tsx
+++ b/frontend/src/components/pages/Client/AboutPage.tsx
@@ -6,8 +6,8 @@ import ViewBox from "./About&Office/ViewBox";
 import WriteBox from "./About&Office/WriteBox";
 import EditModal from "./About&Office/EditModal";
 import {
-  AboutAndOfficeStore,
   ImgPreviewStore,
+  UseModalStore,
   WriteAboutStore,
 } from "@/store/userStore";
 import ImgSlice from "./About&Office/ImgSlice";
@@ -29,7 +29,7 @@ export default function AboutPage() {
   const { setImagePreview, imgList, setIndex, setImgList, setImgLength } =
     ImgPreviewStore();
   const { editSection, setEditSection } = WriteAboutStore();
-  const { isModalOpen, setIsModalOpen } = AboutAndOfficeStore();
+  const { isModalOpen, setIsModalOpen } = UseModalStore();
   // const [imgLength, setImgLength] = useState<number>(0);
 
   // 저장되어있던 이미지 데이터 불러오기

--- a/frontend/src/components/pages/Client/GalleryPage.tsx
+++ b/frontend/src/components/pages/Client/GalleryPage.tsx
@@ -1,45 +1,34 @@
 import Button from "@/components/common/Button";
 import PageHeader from "@/components/common/PageHeader";
+import Masonry from "react-masonry-css";
 import { ControlModalStore, UseModalStore } from "@/store/userStore";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import EditModal from "./About&Office/EditModal";
 import PageCountUI from "@/components/common/PageCountUI";
-import { GetGalleryImages } from "@/api/postApi";
+import { GetGalleryImages, GetGalleryPage } from "@/api/postApi";
 import { GallerySlide } from "@/types/forms";
 import ImageOverlay from "@/components/common/ImageOverlay";
 
+const breakpointColumnsObj = {
+  default: 3,
+  1100: 2,
+  700: 1,
+};
+
 const Div = styled.div`
   margin-bottom: 170px;
+  img {
+    width: 100%;
+    margin-bottom: 16px;
+    cursor: pointer;
+  }
 `;
 
 const ButtonWrap = styled.div`
   display: flex;
   justify-content: flex-end;
   margin-bottom: 20px;
-`;
-
-const Ul = styled.ul`
-  width: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-`;
-const Li = styled.li`
-  padding: 12px;
-  box-sizing: border-box;
-  width: 25%;
-  min-width: 276px;
-  overflow: hidden;
-  aspect-ratio: 1 / 1; // 1:1 정사각형
-  cursor: pointer;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-  }
 `;
 
 export default function GalleryPage() {
@@ -56,6 +45,16 @@ export default function GalleryPage() {
     setIsModalOpen(!isModalOpen);
   };
 
+  useEffect(() => {
+    const fatchGalleryImg = async () => {
+      const res = await GetGalleryPage();
+      if (res.success) {
+        setForm(res.result);
+      }
+    };
+    fatchGalleryImg();
+  }, []);
+
   const handleOverlay = (ImgSrc: string) => {
     setImageModal(true);
     setImageSrc(ImgSrc);
@@ -71,20 +70,22 @@ export default function GalleryPage() {
           onClick={handleModalOpen}
         />
       </ButtonWrap>
-      <Ul>
-        {form.map((item, index) => {
-          return (
-            <Li onClick={() => handleOverlay(item.image_url)} key={index}>
-              <img src={item.image_url} alt="갤러리 이미지" />
-            </Li>
-          );
-        })}
-      </Ul>
-      <PageCountUI<GallerySlide>
-        form={form}
-        setForm={setForm}
-        type="GalleryImage"
-      />
+
+      <Masonry
+        breakpointCols={breakpointColumnsObj}
+        className="my-masonry-grid"
+        columnClassName="my-masonry-grid_column"
+      >
+        {form?.map((img, index) => (
+          <img
+            key={index}
+            src={img.image_url}
+            alt="드림 유학원 관련 이미지"
+            loading="lazy"
+            onClick={() => handleOverlay(img.image_url)}
+          />
+        ))}
+      </Masonry>
 
       {ImageModal && <ImageOverlay />}
       {isModalOpen && <EditModal />}

--- a/frontend/src/components/pages/Client/GalleryPage.tsx
+++ b/frontend/src/components/pages/Client/GalleryPage.tsx
@@ -1,5 +1,88 @@
-import React from "react";
+import Button from "@/components/common/Button";
+import PageHeader from "@/components/common/PageHeader";
+import { UseModalStore } from "@/store/userStore";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import EditModal from "./About&Office/EditModal";
+import PageCountUI from "@/components/common/PageCountUI";
+import { GetGalleryImages } from "@/api/postApi";
+import { GallerySlide } from "@/types/forms";
+
+const Div = styled.div`
+  margin-bottom: 170px;
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+`;
+
+const Ul = styled.ul`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+const Li = styled.li`
+  padding: 12px;
+  box-sizing: border-box;
+  width: 25%;
+  min-width: 276px;
+  overflow: hidden;
+  aspect-ratio: 1 / 1; // 1:1 정사각형
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
 
 export default function GalleryPage() {
-  return <div>GalleryPage</div>;
+  const { isModalOpen, setIsModalOpen } = UseModalStore();
+  const [form, setForm] = useState<GallerySlide[]>([]);
+  const handleModalOpen = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  // useEffect(() => {
+  //   const fetchImage = async () => {
+  //     const res = await GetGalleryImages();
+  //     setForm(res.slides);
+  //     console.log(res);
+  //   };
+  //   fetchImage();
+  // }, []);
+  return (
+    <Div>
+      <PageHeader title="갤러리" root="갤러리" />
+      <ButtonWrap>
+        <Button
+          name="이미지 수정"
+          Bgcolor="green"
+          TitleColor="white"
+          onClick={handleModalOpen}
+        />
+      </ButtonWrap>
+      <Ul>
+        {form.map((item, index) => {
+          return (
+            <Li>
+              <img src={item.image_url} alt="갤러리 이미지" />
+            </Li>
+          );
+        })}
+      </Ul>
+      <PageCountUI<GallerySlide>
+        form={form}
+        setForm={setForm}
+        type="GalleryImage"
+      />
+
+      {isModalOpen && <EditModal />}
+    </Div>
+  );
 }

--- a/frontend/src/components/pages/Client/GalleryPage.tsx
+++ b/frontend/src/components/pages/Client/GalleryPage.tsx
@@ -1,12 +1,13 @@
 import Button from "@/components/common/Button";
 import PageHeader from "@/components/common/PageHeader";
-import { UseModalStore } from "@/store/userStore";
+import { ControlModalStore, UseModalStore } from "@/store/userStore";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import EditModal from "./About&Office/EditModal";
 import PageCountUI from "@/components/common/PageCountUI";
 import { GetGalleryImages } from "@/api/postApi";
 import { GallerySlide } from "@/types/forms";
+import ImageOverlay from "@/components/common/ImageOverlay";
 
 const Div = styled.div`
   margin-bottom: 170px;
@@ -42,20 +43,23 @@ const Li = styled.li`
 `;
 
 export default function GalleryPage() {
-  const { isModalOpen, setIsModalOpen } = UseModalStore();
+  const {
+    isModalOpen,
+    setIsModalOpen,
+    ImageModal,
+    setImageModal,
+    ImageSrc,
+    setImageSrc,
+  } = UseModalStore();
   const [form, setForm] = useState<GallerySlide[]>([]);
   const handleModalOpen = () => {
     setIsModalOpen(!isModalOpen);
   };
 
-  // useEffect(() => {
-  //   const fetchImage = async () => {
-  //     const res = await GetGalleryImages();
-  //     setForm(res.slides);
-  //     console.log(res);
-  //   };
-  //   fetchImage();
-  // }, []);
+  const handleOverlay = (ImgSrc: string) => {
+    setImageModal(true);
+    setImageSrc(ImgSrc);
+  };
   return (
     <Div>
       <PageHeader title="갤러리" root="갤러리" />
@@ -70,7 +74,7 @@ export default function GalleryPage() {
       <Ul>
         {form.map((item, index) => {
           return (
-            <Li>
+            <Li onClick={() => handleOverlay(item.image_url)} key={index}>
               <img src={item.image_url} alt="갤러리 이미지" />
             </Li>
           );
@@ -82,6 +86,7 @@ export default function GalleryPage() {
         type="GalleryImage"
       />
 
+      {ImageModal && <ImageOverlay />}
       {isModalOpen && <EditModal />}
     </Div>
   );

--- a/frontend/src/components/pages/Client/Office.tsx
+++ b/frontend/src/components/pages/Client/Office.tsx
@@ -3,8 +3,8 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import ImgSlice from "./About&Office/ImgSlice";
 import {
-  AboutAndOfficeStore,
   ImgPreviewStore,
+  UseModalStore,
   WriteAboutStore,
 } from "@/store/userStore";
 import EditModal from "./About&Office/EditModal";
@@ -17,7 +17,7 @@ const Div = styled.div`
 `;
 
 export default function Office() {
-  const { isModalOpen, setIsModalOpen } = AboutAndOfficeStore();
+  const { isModalOpen, setIsModalOpen } = UseModalStore();
   const { setImagePreview, imgList, setIndex, setImgList, setImgLength } =
     ImgPreviewStore();
   const { editSection, setEditSection } = WriteAboutStore();

--- a/frontend/src/components/pages/Client/Question/DetailAnswer.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailAnswer.tsx
@@ -21,6 +21,8 @@ const ATitle = styled.div`
 `;
 
 const Amessage = styled.div`
+  white-space: pre-line;
+  line-height: 1.5;
   padding: 30px;
 `;
 type Props = {
@@ -41,7 +43,7 @@ export default function DetailAnswer({ answer }: Props) {
           <span>{`${year}.${month}.${date}`}</span>
         </div>
       </ATitle>
-      <Amessage>답변 내용입니다. 감사합니다.</Amessage>
+      <Amessage>{answer.content}</Amessage>
     </ASection>
   );
 }

--- a/frontend/src/components/pages/Client/Question/DetailAnswer.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailAnswer.tsx
@@ -1,0 +1,47 @@
+import { AnswerData } from "@/types/forms";
+import React from "react";
+import styled from "styled-components";
+
+const ASection = styled.section`
+  background-color: #f8f8f8;
+`;
+
+const ATitle = styled.div`
+  background-color: #f8f8f8;
+  border-bottom: 1px solid #dddddd;
+  padding: 20px 25px;
+  display: flex;
+  justify-content: space-between;
+
+  .meta-Info {
+    color: #888888;
+    display: flex;
+    gap: 12px;
+  }
+`;
+
+const Amessage = styled.div`
+  padding: 30px;
+`;
+type Props = {
+  answer: AnswerData;
+};
+export default function DetailAnswer({ answer }: Props) {
+  const dateObj = answer?.createdAt ? new Date(answer.createdAt) : null;
+  const year = dateObj ? dateObj.getFullYear() : "";
+  const month = dateObj ? String(dateObj.getMonth() + 1).padStart(2, "0") : "";
+  const date = dateObj ? String(dateObj.getDate()).padStart(2, "0") : "";
+  return (
+    <ASection>
+      <ATitle>
+        <h2 className="Question_title">고객센터 담당자의 답변</h2>
+        <div className="meta-Info">
+          <span>admin</span>
+          <span>|</span>
+          <span>{`${year}.${month}.${date}`}</span>
+        </div>
+      </ATitle>
+      <Amessage>답변 내용입니다. 감사합니다.</Amessage>
+    </ASection>
+  );
+}

--- a/frontend/src/components/pages/Client/Question/DetailButtons.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailButtons.tsx
@@ -1,6 +1,7 @@
+import { DeleteQuestion } from "@/api/postApi";
 import { AnswerData } from "@/types/forms";
 import React, { SetStateAction } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 const Div = styled.div`
@@ -47,6 +48,7 @@ export default function DetailButtons({
   setVeiwWriteAnswer,
   answer,
 }: Props) {
+  const { id } = useParams<{ id: string }>();
   const naviagte = useNavigate();
 
   const handleBack = () => {
@@ -56,6 +58,16 @@ export default function DetailButtons({
   const handleChange = () => {
     setVeiwWriteAnswer((prev) => !prev);
   };
+
+  const handleDelete = async () => {
+    if (!id) return;
+    const res = await DeleteQuestion(id);
+    console.log(res);
+    if (res.success) {
+      alert("삭제가 완료되었습니다.");
+      naviagte(-1);
+    }
+  };
   return (
     <Div>
       <Button onClick={handleBack}>뒤로가기</Button>
@@ -63,7 +75,7 @@ export default function DetailButtons({
         <ConfirmButton onClick={handleChange}>
           {ViewWriteAnswer ? "입력취소" : answer ? "답변수정" : "답변달기"}
         </ConfirmButton>
-        <DeleteButton>질문삭제</DeleteButton>
+        <DeleteButton onClick={handleDelete}>질문삭제</DeleteButton>
       </Wrap>
     </Div>
   );

--- a/frontend/src/components/pages/Client/Question/DetailButtons.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailButtons.tsx
@@ -1,3 +1,4 @@
+import { AnswerData } from "@/types/forms";
 import React, { SetStateAction } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
@@ -39,10 +40,12 @@ const ConfirmButton = styled(Button)`
 type Props = {
   ViewWriteAnswer: boolean;
   setVeiwWriteAnswer: React.Dispatch<SetStateAction<boolean>>;
+  answer?: AnswerData;
 };
 export default function DetailButtons({
   ViewWriteAnswer,
   setVeiwWriteAnswer,
+  answer,
 }: Props) {
   const naviagte = useNavigate();
 
@@ -58,7 +61,7 @@ export default function DetailButtons({
       <Button onClick={handleBack}>뒤로가기</Button>
       <Wrap>
         <ConfirmButton onClick={handleChange}>
-          {ViewWriteAnswer ? "입력취소" : "답변달기"}
+          {ViewWriteAnswer ? "입력취소" : answer ? "답변수정" : "답변달기"}
         </ConfirmButton>
         <DeleteButton>질문삭제</DeleteButton>
       </Wrap>

--- a/frontend/src/components/pages/Client/Question/DetailButtons.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailButtons.tsx
@@ -1,0 +1,67 @@
+import React, { SetStateAction } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+const Div = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+`;
+
+const Wrap = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const Button = styled.button`
+  background-color: #eaeaea;
+  color: #888888;
+  padding: 6px 20px;
+  border-radius: 3px;
+  border: none;
+  font-size: 16px;
+  box-sizing: border-box;
+  line-height: 1.5;
+  cursor: pointer;
+`;
+
+const DeleteButton = styled(Button)`
+  background-color: #c93e3e;
+  color: white;
+`;
+
+const ConfirmButton = styled(Button)`
+  background-color: white;
+  color: #49b736;
+  font-weight: 600;
+  border: 1px solid #49b736;
+`;
+type Props = {
+  ViewWriteAnswer: boolean;
+  setVeiwWriteAnswer: React.Dispatch<SetStateAction<boolean>>;
+};
+export default function DetailButtons({
+  ViewWriteAnswer,
+  setVeiwWriteAnswer,
+}: Props) {
+  const naviagte = useNavigate();
+
+  const handleBack = () => {
+    naviagte(-1);
+  };
+
+  const handleChange = () => {
+    setVeiwWriteAnswer((prev) => !prev);
+  };
+  return (
+    <Div>
+      <Button onClick={handleBack}>뒤로가기</Button>
+      <Wrap>
+        <ConfirmButton onClick={handleChange}>
+          {ViewWriteAnswer ? "입력취소" : "답변달기"}
+        </ConfirmButton>
+        <DeleteButton>질문삭제</DeleteButton>
+      </Wrap>
+    </Div>
+  );
+}

--- a/frontend/src/components/pages/Client/Question/DetailQuestion.tsx
+++ b/frontend/src/components/pages/Client/Question/DetailQuestion.tsx
@@ -1,0 +1,57 @@
+import { QuestionData } from "@/types/forms";
+import React from "react";
+import styled from "styled-components";
+
+const QTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 25px;
+  border-top: 1px solid #111111;
+  border-bottom: 1px solid #111111;
+  margin-top: 60px;
+
+  .meta-Info {
+    color: #888888;
+    display: flex;
+    gap: 12px;
+  }
+`;
+
+const QMessage = styled.div`
+  padding: 30px;
+  border-bottom: 1px solid #dddddd;
+  display: flex;
+  flex-direction: column;
+`;
+const QImage = styled.div`
+  margin: 70px 0;
+`;
+
+type Props = {
+  question: QuestionData;
+};
+
+export default function DetailQuestion({ question }: Props) {
+  const dateObj = question?.createdAt ? new Date(question.createdAt) : null;
+  const year = dateObj ? dateObj.getFullYear() : "";
+  const month = dateObj ? String(dateObj.getMonth() + 1).padStart(2, "0") : "";
+  const date = dateObj ? String(dateObj.getDate()).padStart(2, "0") : "";
+  return (
+    <section>
+      <QTitle>
+        <h2 className="Question_title">{question?.title}</h2>
+        <div className="meta-Info">
+          <span>{question?.nickname}</span>
+          <span>|</span>
+          <span>{`${year}.${month}.${date}`}</span>
+        </div>
+      </QTitle>
+      <QMessage>{question?.message}</QMessage>
+      <QImage>
+        {question?.file.map((item, index) => {
+          return <img src={item} alt="질문 등록 이미지" key={index} />;
+        })}
+      </QImage>
+    </section>
+  );
+}

--- a/frontend/src/components/pages/Client/Question/QTableLIstItems.tsx
+++ b/frontend/src/components/pages/Client/Question/QTableLIstItems.tsx
@@ -43,7 +43,7 @@ export default function QTableLIstItems({
 }: TableListItemProps) {
   const navigate = useNavigate();
   const { currentPage } = ReservationMyListStore();
-  const { setViewModal } = ControlModalStore();
+  const { setViewModal, setPostId } = ControlModalStore();
   const [startIndex, setStartIndex] = useState<number>(0);
   const listNumber = startIndex + orderNum;
   // 날짜 조정
@@ -62,6 +62,7 @@ export default function QTableLIstItems({
   const handleClick = () => {
     if (form.isPrivate) {
       setViewModal(true);
+      setPostId(form.id);
     } else {
       navigate(`/questions/${form.id}`);
     }

--- a/frontend/src/components/pages/Client/Question/Search.tsx
+++ b/frontend/src/components/pages/Client/Question/Search.tsx
@@ -1,0 +1,116 @@
+import { getSearch } from "@/api/postApi";
+import { ReservationMyListStore, SearchStore } from "@/store/userStore";
+import { QuestionData } from "@/types/forms";
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
+
+const Section = styled.section`
+  background-color: #f8f8f8;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0;
+  margin: 50px 0 30px;
+  gap: 12px;
+`;
+const Select = styled.select`
+  padding: 7px 8px;
+  border: 1px solid #dddddd;
+`;
+const Input = styled.input`
+  padding: 7px 16px;
+  border: 1px solid #dddddd;
+  width: 300px;
+`;
+const SearchButtton = styled.button`
+  color: white;
+  background-color: #49b736;
+  border: none;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+`;
+
+interface MyListSectionProps {
+  setForm: React.Dispatch<React.SetStateAction<QuestionData[]>>;
+}
+
+export default function Search({ setForm }: MyListSectionProps) {
+  const [keyword, setKeyword] = useState("");
+  const [searchField, setSearchField] = useState("title");
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const { setSearchList, setSearchData } = SearchStore();
+  const { setCurrentPage } = ReservationMyListStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+  };
+
+  const handleField = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSearchField(e.target.value);
+  };
+
+  // 검색 수행
+  const handleSearch = async () => {
+    // 아무것도 입력 안했을 경우 전체 리스트 보여주기
+    if (keyword === "") {
+      setSearchList(false);
+      return;
+    }
+    // 입력 키워드를 토대로 검색 수행
+    const res = await getSearch(keyword, searchField);
+    // 게시글 데이터가 든 배열을 변수에 담아둔다.
+    const searchData = res.result;
+    // 성공적으로 받아왔을 경우 수행
+    if (res.success) {
+      setSearchList(true); // 페이지 카운트ui를 검색 전용으로 변경
+      if (res.result.length <= 10) {
+        // 10개 이하인 데이터는 페이지 변경이 필요없으니 바로 렌더링
+        setCurrentPage(1);
+        setSearchData(res.result);
+        setForm(res.result);
+      } else if (res.result.length > 10) {
+        // 10개 이상의 데이터는 초기 10개만 잘라서 표시한다.
+        const limit = 10;
+        const offset = 0;
+        const sliced = searchData.slice(offset, offset + limit);
+        setSearchData(res.result); // 검색 결과 담아두기
+        setForm(sliced); // 실질적인 리스트 렌더링
+      } else if (res.result.length === 0) {
+        alert("검색 결과가 존재하지 않습니다.");
+        return;
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && buttonRef) handleSearch();
+  };
+  return (
+    <Section>
+      <Select name="searchField" id="searchField" onChange={handleField}>
+        <option value="title">제목</option>
+        <option value="nickname">글쓴이</option>
+      </Select>
+      <Input
+        type="text"
+        placeholder="검색어를 입력하세요"
+        value={keyword}
+        onChange={(e) => handleChange(e)}
+        onKeyDown={handleKeyDown}
+      />
+      <SearchButtton onClick={handleSearch} ref={buttonRef}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-search"
+          viewBox="0 0 16 16"
+        >
+          <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0" />
+        </svg>
+      </SearchButtton>
+    </Section>
+  );
+}

--- a/frontend/src/components/pages/Client/Question/WriteAnswer.tsx
+++ b/frontend/src/components/pages/Client/Question/WriteAnswer.tsx
@@ -1,5 +1,129 @@
-import React from "react";
+import { PostAnswerSubmit } from "@/api/postApi";
+import Button from "@/components/common/Button";
+import { AnswerData } from "@/types/forms";
+import React, { SetStateAction, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
 
-export default function WriteAnswer() {
-  return <div>WriteAnswer</div>;
+const ATitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 25px;
+  border-top: 1px solid #111111;
+  border-bottom: 1px solid #111111;
+  margin-top: 60px;
+  .Answer_title {
+    font-size: 24px;
+    font-weight: 700;
+  }
+
+  .meta-Info {
+    color: #888888;
+    display: flex;
+    gap: 12px;
+  }
+`;
+
+const AMessage = styled.div`
+  padding: 50px;
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+  border-bottom: 1px solid #dddddd;
+
+  label {
+    line-height: 44px;
+    font-size: 18px;
+    font-weight: 500;
+    width: 20%;
+    display: block;
+    text-align: left;
+  }
+
+  textarea {
+    flex-grow: 1;
+    height: 400px;
+    padding: 17px 0 0 19px;
+    border: 1px solid #dddddd;
+    font-size: 16px;
+    width: 100%;
+  }
+`;
+const AButtonBox = styled.div`
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 70px;
+`;
+const StyleButton = styled(Button)`
+  padding: 15px 45px;
+  font-size: 16px;
+  border-radius: 8px;
+`;
+
+const Section = styled.div`
+  margin-bottom: 140px;
+`;
+interface Props {
+  setVeiwWriteAnswer: React.Dispatch<SetStateAction<boolean>>;
+  answer?: AnswerData;
+}
+export default function WriteAnswer({ setVeiwWriteAnswer, answer }: Props) {
+  const { id } = useParams<{ id: string }>();
+  const [message, setMessage] = useState("");
+
+  // 이미 답변이 있는 경우 가져와서 텍스트 창에 붙이기
+  useEffect(() => {
+    setMessage(answer?.content || "");
+  }, [answer]);
+
+  const hancleCancle = () => {
+    alert("입력창이 닫힙니다.");
+    setVeiwWriteAnswer(false);
+  };
+
+  const handleAnserSubmit = async () => {
+    if (!id) return;
+    const res = await PostAnswerSubmit(id, message);
+    console.log(res);
+    if (res.success) {
+      setVeiwWriteAnswer(false);
+    }
+  };
+
+  const handleChangeMessage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+  };
+  return (
+    <Section>
+      <ATitle>
+        <h2 className="Answer_title">답변 작성</h2>
+      </ATitle>
+      <AMessage>
+        <label htmlFor="answer">답변사항</label>
+        <textarea
+          name="answer"
+          id="answer"
+          placeholder="내용을 입력해주세요"
+          value={message}
+          onChange={(e) => handleChangeMessage(e)}
+        />
+      </AMessage>
+      <AButtonBox>
+        <StyleButton
+          name="취소"
+          Bgcolor="grey"
+          TitleColor="darkGrey"
+          onClick={hancleCancle}
+        />
+        <StyleButton
+          name="등록"
+          Bgcolor="green"
+          TitleColor="white"
+          onClick={handleAnserSubmit}
+        />
+      </AButtonBox>
+    </Section>
+  );
 }

--- a/frontend/src/components/pages/Client/Question/WriteAnswer.tsx
+++ b/frontend/src/components/pages/Client/Question/WriteAnswer.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function WriteAnswer() {
+  return <div>WriteAnswer</div>;
+}

--- a/frontend/src/components/pages/Client/QuestionDetail.tsx
+++ b/frontend/src/components/pages/Client/QuestionDetail.tsx
@@ -1,7 +1,15 @@
-import React from "react";
+import { GetQuestion } from "@/api/postApi";
+import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 
 export default function QuestionDetail() {
   const { id } = useParams<{ id: string }>();
+  useEffect(() => {
+    const handleGetQuestion = async () => {
+      if (!id) return;
+      const res = await GetQuestion(id);
+    };
+    handleGetQuestion();
+  }, [id]);
   return <div>QuestionDetail</div>;
 }

--- a/frontend/src/components/pages/Client/QuestionDetail.tsx
+++ b/frontend/src/components/pages/Client/QuestionDetail.tsx
@@ -1,15 +1,55 @@
-import { GetQuestion } from "@/api/postApi";
-import React, { useEffect } from "react";
+import { GetAnswer, GetQuestion } from "@/api/postApi";
+import PageHeader from "@/components/common/PageHeader";
+import { AnswerData, QuestionData } from "@/types/forms";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import styled from "styled-components";
+
+import DetailQuestion from "./Question/DetailQuestion";
+import DetailButtons from "./Question/DetailButtons";
+import DetailAnswer from "./Question/DetailAnswer";
+import WriteAnswer from "./Question/WriteAnswer";
+
+const Div = styled.div`
+  .Question_title {
+    font-size: 24px;
+    font-weight: 700;
+  }
+`;
 
 export default function QuestionDetail() {
+  const [question, setQuestion] = useState<QuestionData>();
+  const [answer, setAnswer] = useState<AnswerData>();
+  const [ViewWriteAnswer, setVeiwWriteAnswer] = useState(false);
   const { id } = useParams<{ id: string }>();
+
   useEffect(() => {
     const handleGetQuestion = async () => {
       if (!id) return;
-      const res = await GetQuestion(id);
+      const question = await GetQuestion(id);
+      setQuestion(question.result);
+      const answer = await GetAnswer(id);
+      console.log(answer);
+      setAnswer(answer.Answer);
     };
     handleGetQuestion();
   }, [id]);
-  return <div>QuestionDetail</div>;
+
+  return (
+    <Div>
+      <PageHeader
+        title="질문확인"
+        root="질문게시판"
+        root1Url="/questions"
+        root2="질문확인"
+      />
+      <DetailButtons
+        ViewWriteAnswer={ViewWriteAnswer}
+        setVeiwWriteAnswer={setVeiwWriteAnswer}
+      />
+      {question && <DetailQuestion question={question} />}
+      {answer && <DetailAnswer answer={answer} />}
+      {ViewWriteAnswer && <WriteAnswer />}
+    </Div>
+  );
 }

--- a/frontend/src/components/pages/Client/QuestionDetail.tsx
+++ b/frontend/src/components/pages/Client/QuestionDetail.tsx
@@ -11,6 +11,7 @@ import DetailAnswer from "./Question/DetailAnswer";
 import WriteAnswer from "./Question/WriteAnswer";
 
 const Div = styled.div`
+  margin-bottom: 170px;
   .Question_title {
     font-size: 24px;
     font-weight: 700;
@@ -28,12 +29,11 @@ export default function QuestionDetail() {
       if (!id) return;
       const question = await GetQuestion(id);
       setQuestion(question.result);
-      const answer = await GetAnswer(id);
-      console.log(answer);
-      setAnswer(answer.Answer);
+      const resultA = await GetAnswer(id);
+      setAnswer(resultA.result);
     };
     handleGetQuestion();
-  }, [id]);
+  }, [id, ViewWriteAnswer]);
 
   return (
     <Div>
@@ -46,10 +46,13 @@ export default function QuestionDetail() {
       <DetailButtons
         ViewWriteAnswer={ViewWriteAnswer}
         setVeiwWriteAnswer={setVeiwWriteAnswer}
+        answer={answer}
       />
       {question && <DetailQuestion question={question} />}
       {answer && <DetailAnswer answer={answer} />}
-      {ViewWriteAnswer && <WriteAnswer />}
+      {ViewWriteAnswer && (
+        <WriteAnswer setVeiwWriteAnswer={setVeiwWriteAnswer} answer={answer} />
+      )}
     </Div>
   );
 }

--- a/frontend/src/components/pages/Client/QuestionsPage.tsx
+++ b/frontend/src/components/pages/Client/QuestionsPage.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@/components/common/PageHeader";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import TableForm from "./Reservation/TableForm";
 import Button from "@/components/common/Button";
@@ -8,16 +8,8 @@ import PageCountUI from "@/components/common/PageCountUI";
 import { QuestionData } from "@/types/forms";
 import QTableLIstItems from "./Question/QTableLIstItems";
 import ModalUI from "@/components/common/ModalUI";
-import { ControlModalStore } from "@/store/userStore";
-
-const Section = styled.section`
-  background-color: #f8f8f8;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 20px 0;
-  margin: 50px 0 30px;
-`;
+import { ControlModalStore, SearchStore } from "@/store/userStore";
+import Search from "./Question/Search";
 
 const Div = styled.div`
   display: flex;
@@ -34,17 +26,17 @@ const ButtonWrap = styled.div`
 export default function QuestionsPage() {
   const { viewModal } = ControlModalStore();
   const [form, setForm] = useState<QuestionData[]>([]);
+  const { searchList, setSearchList } = SearchStore();
+
+  useEffect(() => {
+    setSearchList(false);
+    return () => setSearchList(false); // cleanup
+  }, []);
+
   return (
     <Div>
       <PageHeader title="질문게시판" root="질문게시판" />
-      <Section>
-        <select name="" id="">
-          <option value="제목">제목</option>
-          <option value="글쓴이">글쓴이</option>
-        </select>
-        <input type="text" placeholder="검색어를 입력하세요" />
-        <button>확인</button>
-      </Section>
+      <Search setForm={setForm} />
       <TableForm<QuestionData>
         form={form}
         headers={["번호", "제목", "글쓴이", "등록일", "답변여부"]}
@@ -58,11 +50,20 @@ export default function QuestionsPage() {
           <Button name="글쓰기" Bgcolor="green" TitleColor="white" />
         </Link>
       </ButtonWrap>
-      <PageCountUI<QuestionData>
-        type="QuestionSubmitList"
-        form={form}
-        setForm={setForm}
-      />
+
+      {searchList ? (
+        <PageCountUI<QuestionData>
+          type="SearchList"
+          form={form}
+          setForm={setForm}
+        />
+      ) : (
+        <PageCountUI<QuestionData>
+          type="QuestionSubmitList"
+          form={form}
+          setForm={setForm}
+        />
+      )}
       {viewModal && <ModalUI />}
     </Div>
   );

--- a/frontend/src/components/pages/Client/Reservation/InputGroup/FormRow.tsx
+++ b/frontend/src/components/pages/Client/Reservation/InputGroup/FormRow.tsx
@@ -15,6 +15,7 @@ const Label = styled.label`
   font-size: 18px;
   font-weight: 500;
   width: 20%;
+  min-width: 180px;
   display: block;
   text-align: left;
 `;

--- a/frontend/src/components/pages/Client/main/AboutModal.tsx
+++ b/frontend/src/components/pages/Client/main/AboutModal.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import styled from "styled-components";
+import FormRow from "../Reservation/InputGroup/FormRow";
+import TitleInputGroup from "./TitleInputGroup";
+import SubTitleInputGroup from "./SubTitleInputGroup";
+import { MainStore } from "@/store/userStore";
+import ImgInputGroup from "../Reservation/InputGroup/ImgInputGroup";
+
+import MainModalButtonBox from "./MainModalButtonBox";
+import MainImgInput from "./MainImgInput";
+
+const Div = styled.div`
+  position: fixed;
+  z-index: 20;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 880px;
+  height: 850px;
+  background-color: white;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  border-radius: 20px;
+  text-align: center;
+  padding: 60px 40px 0;
+  box-sizing: border-box;
+  overflow: auto;
+  scrollbar-width: none;
+
+  h2 {
+    padding-bottom: 44px;
+    border-bottom: 1px solid #dddddd;
+  }
+`;
+
+const Section = styled.section`
+  padding: 40px;
+`;
+const Textarea = styled.textarea`
+  flex-grow: 1;
+  padding: 17px 0 0 19px;
+  border: 1px solid #dddddd;
+  font-size: 16px;
+  min-height: 150px;
+`;
+
+export default function AboutModal() {
+  const { message, setMessage } = MainStore();
+  return (
+    <Div>
+      <h2 className="Section-title">타이틀 수정</h2>
+      <Section>
+        <FormRow
+          htmlFor="title1"
+          label="타이틀1"
+          required={true}
+          NeedWrapper={false}
+        >
+          <TitleInputGroup />
+        </FormRow>
+        <FormRow
+          htmlFor="title2"
+          label="타이틀2"
+          required={true}
+          NeedWrapper={false}
+        >
+          <SubTitleInputGroup />
+        </FormRow>
+
+        <FormRow
+          htmlFor="inquiry"
+          label="핵심문의사항"
+          required={false}
+          NeedWrapper={false}
+        >
+          <Textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            name="Description"
+            id="Description"
+            placeholder="내용을 입력해 주세요"
+          />
+        </FormRow>
+        <FormRow
+          htmlFor="photoUpload"
+          label="사진첨부"
+          required={false}
+          NeedWrapper={false}
+        >
+          <MainImgInput />
+        </FormRow>
+        <MainModalButtonBox />
+      </Section>
+    </Div>
+  );
+}

--- a/frontend/src/components/pages/Client/main/AboutModal.tsx
+++ b/frontend/src/components/pages/Client/main/AboutModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import FormRow from "../Reservation/InputGroup/FormRow";
 import TitleInputGroup from "./TitleInputGroup";
@@ -8,6 +8,8 @@ import ImgInputGroup from "../Reservation/InputGroup/ImgInputGroup";
 
 import MainModalButtonBox from "./MainModalButtonBox";
 import MainImgInput from "./MainImgInput";
+import { GetMainAbout } from "@/api/postApi";
+import { MainDataProps } from "@/types/forms";
 
 const Div = styled.div`
   position: fixed;
@@ -42,9 +44,25 @@ const Textarea = styled.textarea`
   font-size: 16px;
   min-height: 150px;
 `;
-
+const Span = styled.span`
+  color: #888888;
+`;
 export default function AboutModal() {
-  const { message, setMessage } = MainStore();
+  const { message, setMessage, setMainAbout, MainAbout, setTitle1, setTitle2 } =
+    MainStore();
+  useEffect(() => {
+    const fetchMain = async () => {
+      const res = await GetMainAbout();
+      if (res.result) {
+        setMainAbout(res.result); // 전체 데이터 저장
+        setTitle1(res.result.title_main);
+        setTitle2(res.result.title_sub);
+        setMessage(res.result.content);
+      }
+    };
+    fetchMain();
+  }, []);
+
   return (
     <Div>
       <h2 className="Section-title">타이틀 수정</h2>
@@ -88,6 +106,7 @@ export default function AboutModal() {
         >
           <MainImgInput />
         </FormRow>
+        <Span>※ 이미지 미첨부 시 이전 이미지가 적용됩니다.</Span>
         <MainModalButtonBox />
       </Section>
     </Div>

--- a/frontend/src/components/pages/Client/main/Main.tsx
+++ b/frontend/src/components/pages/Client/main/Main.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import axios from "axios";
 import { postUpload } from "../../../../api/postApi";
 

--- a/frontend/src/components/pages/Client/main/Main.tsx
+++ b/frontend/src/components/pages/Client/main/Main.tsx
@@ -6,9 +6,12 @@ import SectionAbout from "./SectionAbout";
 import SectionOffice from "./SectionOffice";
 import SectionNews from "./SectionNews";
 import SectionGallery from "./SectionGallery";
+import { MainStore } from "@/store/userStore";
+import AboutModal from "./AboutModal";
 
 export default function Main() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const { isModalOpen } = MainStore();
 
   // 파일 업로드 되면 상태값으로 저장
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -38,6 +41,7 @@ export default function Main() {
       <SectionOffice />
       <SectionNews />
       <SectionGallery />
+      {isModalOpen && <AboutModal />}
     </div>
   );
 }

--- a/frontend/src/components/pages/Client/main/Main.tsx
+++ b/frontend/src/components/pages/Client/main/Main.tsx
@@ -1,7 +1,3 @@
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { postUpload } from "../../../../api/postApi";
-
 import SectionAbout from "./SectionAbout";
 import SectionOffice from "./SectionOffice";
 import SectionNews from "./SectionNews";
@@ -10,33 +6,10 @@ import { MainStore } from "@/store/userStore";
 import AboutModal from "./AboutModal";
 
 export default function Main() {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const { isModalOpen } = MainStore();
-
-  // 파일 업로드 되면 상태값으로 저장
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setSelectedFile(e.target.files[0]);
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!selectedFile) return;
-
-    const formData = new FormData();
-    formData.append("image", selectedFile); // 'image'는 백엔드에서 받는 key
-
-    try {
-      const response = await postUpload(formData);
-    } catch (error) {
-      console.error("업로드 실패", error);
-    }
-  };
 
   return (
     <div>
-      {/* <input type="file" accept="image/*" onChange={handleChange} />
-        <button onClick={handleSubmit}>업로드</button> */}
       <SectionAbout />
       <SectionOffice />
       <SectionNews />

--- a/frontend/src/components/pages/Client/main/MainImgInput.tsx
+++ b/frontend/src/components/pages/Client/main/MainImgInput.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import DeleteButton from "@/components/common/DeleteButton";
+import { MainStore } from "@/store/userStore";
+import { v4 as uuidv4 } from "uuid";
+
+const ImgDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-grow: 1;
+  width: 100%;
+  gap: 20px;
+  align-items: center;
+  ul {
+    overflow-x: hidden;
+    overflow-y: auto;
+    width: 40%;
+    height: 300px;
+    text-align: left;
+    li {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      padding: 10px;
+      margin-left: 10px;
+    }
+  }
+`;
+
+const ImgLabel = styled.label`
+  color: #888888;
+  border: 2px dashed #dddddd;
+  box-sizing: border-box;
+  padding: 20px 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  cursor: pointer;
+  border-radius: 10px;
+  width: 50%;
+  height: 100%;
+
+  svg {
+    width: 45px;
+    height: 40px;
+  }
+  p {
+    margin-top: 16px;
+    font-size: 16px;
+  }
+`;
+
+const ImgListdiv = styled.div`
+  display: flex;
+  align-items: center;
+  border-bottom: 2px solid #dddddd;
+  width: 50%;
+
+  svg {
+    width: 24px;
+    height: 24px;
+    color: #888888;
+  }
+  span {
+    display: block;
+    width: 70%;
+    flex-grow: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    line-height: 1.5;
+    margin-left: 10px;
+  }
+  button {
+    background-color: transparent;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+  }
+`;
+export default function MainImgInput() {
+  const { file, setFiles } = MainStore();
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files;
+    if (!selectedFile) return;
+
+    const newFiles = Array.from(selectedFile);
+    const newItems = newFiles.map((file) => ({
+      id: uuidv4(), // 또는 uuid(), index.toString() 등
+      file,
+    }));
+    setFiles((prev) => [...prev, ...newItems]);
+  };
+  return (
+    <>
+      <ImgDiv>
+        <ImgLabel
+          htmlFor="photoUpload"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const droppedFiles = e.dataTransfer.files;
+            const file = droppedFiles[0];
+            if (!file) return;
+
+            const newItem = {
+              id: uuidv4(),
+              file,
+            };
+
+            setFiles([newItem]);
+          }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            className="bi bi-image"
+            viewBox="0 0 16 16"
+          >
+            <path d="M6.002 5.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0" />
+            <path d="M2.002 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2zm12 1a1 1 0 0 1 1 1v6.5l-3.777-1.947a.5.5 0 0 0-.577.093l-3.71 3.71-2.66-1.772a.5.5 0 0 0-.63.062L1.002 12V3a1 1 0 0 1 1-1z" />
+          </svg>
+          <p>파일을 선택해주세요</p>
+        </ImgLabel>
+        {file[0] && (
+          <ImgListdiv>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              className="bi bi-file-earmark-text"
+              viewBox="0 0 16 16"
+            >
+              <path d="M5.5 7a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1zM5 9.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5m0 2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5" />
+              <path d="M9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.5zm0 1v2A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z" />
+            </svg>
+            <span>{file[0].file.name}</span>
+            <DeleteButton file={file[0]} setFiles={setFiles} />
+          </ImgListdiv>
+        )}
+      </ImgDiv>
+      <input
+        type="file"
+        id="photoUpload"
+        name="photo"
+        accept="image/*"
+        style={{ display: "none" }}
+        onChange={handleFileChange}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/pages/Client/main/MainModalButtonBox.tsx
+++ b/frontend/src/components/pages/Client/main/MainModalButtonBox.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import Button from "@/components/common/Button";
 import { MainStore } from "@/store/userStore";
+import { title } from "process";
+import { PostMainPage } from "@/api/postApi";
 
 const ButtonBox = styled.div`
   display: flex;
@@ -17,10 +19,42 @@ const StyleButton = styled(Button)`
 `;
 
 export default function MainModalButtonBox() {
-  const { isModalOpen, setIsModalOpen } = MainStore();
+  const {
+    isModalOpen,
+    setIsModalOpen,
+    title1,
+    title2,
+    message,
+    file,
+    MainAbout,
+    setMainAbout,
+    setFiles,
+  } = MainStore();
 
   const handleCancle = () => {
     setIsModalOpen(false);
+  };
+
+  const handleSubmit = async () => {
+    if (title1 === "" || title2 === "" || message === "") {
+      alert("필수 항목을 모두 입력해주세요");
+      return;
+    }
+    if (!MainAbout.image_url) {
+      alert("현재 사용하던 이미지가 없습니다. 사진을 저장해주세요 ");
+    }
+    const formData = new FormData();
+    formData.append("title1", title1);
+    formData.append("title2", title2);
+    formData.append("message", message);
+    file?.forEach(({ file }) => {
+      formData.append("images", file);
+    });
+    const res = await PostMainPage(formData);
+    if (res.message) alert("데이터가 성공적으로 저장되었습니다.");
+    setIsModalOpen(false);
+    setFiles([]);
+    setMainAbout(res.updatedData);
   };
   return (
     <ButtonBox>
@@ -30,7 +64,12 @@ export default function MainModalButtonBox() {
         TitleColor="darkGrey"
         onClick={handleCancle}
       />
-      <StyleButton name="수정" Bgcolor="green" TitleColor="white" />
+      <StyleButton
+        name="수정"
+        Bgcolor="green"
+        TitleColor="white"
+        onClick={handleSubmit}
+      />
     </ButtonBox>
   );
 }

--- a/frontend/src/components/pages/Client/main/MainModalButtonBox.tsx
+++ b/frontend/src/components/pages/Client/main/MainModalButtonBox.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import styled from "styled-components";
+import Button from "@/components/common/Button";
+import { MainStore } from "@/store/userStore";
+
+const ButtonBox = styled.div`
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 60px;
+`;
+const StyleButton = styled(Button)`
+  padding: 15px 45px;
+  font-size: 16px;
+  border-radius: 8px;
+`;
+
+export default function MainModalButtonBox() {
+  const { isModalOpen, setIsModalOpen } = MainStore();
+
+  const handleCancle = () => {
+    setIsModalOpen(false);
+  };
+  return (
+    <ButtonBox>
+      <StyleButton
+        name="취소"
+        Bgcolor="grey"
+        TitleColor="darkGrey"
+        onClick={handleCancle}
+      />
+      <StyleButton name="수정" Bgcolor="green" TitleColor="white" />
+    </ButtonBox>
+  );
+}

--- a/frontend/src/components/pages/Client/main/SectionAbout.tsx
+++ b/frontend/src/components/pages/Client/main/SectionAbout.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { MainStore } from "@/store/userStore";
+import { GetMainAbout } from "@/api/postApi";
 
 const AboutSection = styled.section<{ $imageUrl: string }>`
   display: flex;
@@ -87,13 +88,27 @@ const AboutSection = styled.section<{ $imageUrl: string }>`
   }
 `;
 
+const Paragraph = styled.p`
+  white-space: pre-line;
+`;
 export default function SectionAbout() {
-  const { setIsModalOpen } = MainStore();
+  const { setIsModalOpen, MainAbout, setMainAbout } = MainStore();
   const [imageUrl, setImageUrl] = useState<string>(
     "https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/Layer+3.png"
   );
+
+  useEffect(() => {
+    const fetchMain = async () => {
+      const res = await GetMainAbout();
+      if (res.result) {
+        setMainAbout(res.result);
+        setImageUrl(res.result.image_url);
+      }
+    };
+    fetchMain();
+  }, []);
   return (
-    <AboutSection $imageUrl={imageUrl}>
+    <AboutSection $imageUrl={imageUrl || "defaultBanner.png"}>
       <button onClick={() => setIsModalOpen(true)}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -111,13 +126,15 @@ export default function SectionAbout() {
         </svg>
       </button>
       <div>
-        <h1>해외 의대 전문 유학원</h1>
-        <h2>드림유학원, 당신의 글로벌 미래를 응원합니다.</h2>
-        <p>
-          2020 ~ 2025 우즈베키스탄 의대 전체 수속 학생수 1위
-          <br />
-          2020 ~ 2025 우즈베키스탄 의대 편입 성공 학생수 1위
-        </p>
+        <h1>{MainAbout?.title_main || "해외 의대 전문 유학원"}</h1>
+        <h2>
+          {MainAbout?.title_sub ||
+            "드림유학원, 당신의 글로벌 미래를 응원합니다."}
+        </h2>
+        <Paragraph>
+          {MainAbout?.content ||
+            "2020 ~ 2025 우즈베키스탄 의대 전체 수속 학생수 1위"}
+        </Paragraph>
         <Link to="/about">자세히 보기</Link>
       </div>
     </AboutSection>

--- a/frontend/src/components/pages/Client/main/SectionAbout.tsx
+++ b/frontend/src/components/pages/Client/main/SectionAbout.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { MainStore } from "@/store/userStore";
 
 const AboutSection = styled.section<{ $imageUrl: string }>`
   display: flex;
@@ -87,12 +88,13 @@ const AboutSection = styled.section<{ $imageUrl: string }>`
 `;
 
 export default function SectionAbout() {
+  const { setIsModalOpen } = MainStore();
   const [imageUrl, setImageUrl] = useState<string>(
     "https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/Layer+3.png"
   );
   return (
     <AboutSection $imageUrl={imageUrl}>
-      <button>
+      <button onClick={() => setIsModalOpen(true)}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"

--- a/frontend/src/components/pages/Client/main/SectionAbout.tsx
+++ b/frontend/src/components/pages/Client/main/SectionAbout.tsx
@@ -14,7 +14,7 @@ const AboutSection = styled.section<{ $imageUrl: string }>`
   margin-bottom: 120px;
 
   height: 633px;
-  overflow: hidden;
+  /* overflow: hidden; */
 
   button {
     width: 86px;
@@ -24,8 +24,6 @@ const AboutSection = styled.section<{ $imageUrl: string }>`
     right: 10px;
     top: 10px;
     background-color: transparent;
-    /*background-image: url("./edit.svg");
-    background-repeat: no-repeat; */
 
     color: white;
     border: none;
@@ -39,17 +37,17 @@ const AboutSection = styled.section<{ $imageUrl: string }>`
 
   &::before {
     content: "";
-    width: 100%;
+    width: 100vw;
     height: 100%;
     position: absolute;
     z-index: 0;
 
-    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
       url(${(props) => props.$imageUrl});
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    filter: blur(2px);
+    /* filter: blur(1.8px); */
   }
 
   div {

--- a/frontend/src/components/pages/Client/main/SectionGallery.tsx
+++ b/frontend/src/components/pages/Client/main/SectionGallery.tsx
@@ -1,13 +1,12 @@
-import React from "react";
-import Masonry from "react-masonry-css";
+import React, { useEffect, useState } from "react";
+
 import styled from "styled-components";
 import CustomLink from "../../../common/CustomLink";
+import { GetGalleryImg } from "@/api/postApi";
+import { GallerySlide } from "@/types/forms";
+import { UseModalStore } from "@/store/userStore";
+import ImageOverlay from "@/components/common/ImageOverlay";
 
-const breakpointColumnsObj = {
-  default: 3,
-  1100: 2,
-  700: 1,
-};
 const Section = styled.section`
   position: relative;
   z-index: 1;
@@ -39,18 +38,55 @@ const Header = styled.div`
     position: relative;
   }
 `;
+
+const Ul = styled.ul`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+const Li = styled.li`
+  padding: 12px;
+  box-sizing: border-box;
+  width: 25%;
+  min-width: 276px;
+  overflow: hidden;
+  aspect-ratio: 1 / 1; // 1:1 정사각형
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
 export default function SectionGallery() {
-  const images: string[] = [
-    "./news0.jpg",
-    "./office0.jpg",
-    "./office0.jpg",
-    "./office1.jpg",
-    "./office0.jpg",
-    "./news0.jpg",
-    "./office0.jpg",
-    "./office0.jpg",
-    "./office0.jpg",
-  ];
+  const [images, setImages] = useState<GallerySlide[]>();
+  const [form, setForm] = useState<GallerySlide[]>([]);
+  const {
+    isModalOpen,
+    setIsModalOpen,
+    ImageModal,
+    setImageModal,
+    ImageSrc,
+    setImageSrc,
+  } = UseModalStore();
+
+  const fetchGalleryImg = async () => {
+    const res = await GetGalleryImg();
+    if (res.success) {
+      setImages(res.result);
+    }
+  };
+  useEffect(() => {
+    fetchGalleryImg();
+  }, []);
+
+  const handleOverlay = (ImgSrc: string) => {
+    setImageModal(true);
+    setImageSrc(ImgSrc);
+  };
   return (
     <Section>
       <Header>
@@ -59,20 +95,30 @@ export default function SectionGallery() {
           <CustomLink to={"gallery"} />
         </div>
       </Header>
-      <Masonry
+      <Ul>
+        {images?.map((item, index) => {
+          return (
+            <Li onClick={() => handleOverlay(item.image_url)} key={index}>
+              <img src={item.image_url} alt="갤러리 이미지" />
+            </Li>
+          );
+        })}
+      </Ul>
+      {/* <Masonry
         breakpointCols={breakpointColumnsObj}
         className="my-masonry-grid"
         columnClassName="my-masonry-grid_column"
       >
-        {images.map((img, index) => (
+        {images?.map((img, index) => (
           <img
             key={index}
-            src={img}
+            src={img.image_url}
             alt="드림 유학원 관련 이미지"
             loading="lazy"
           />
         ))}
-      </Masonry>
+      </Masonry> */}
+      {ImageModal && <ImageOverlay />}
     </Section>
   );
 }

--- a/frontend/src/components/pages/Client/main/SectionNews.tsx
+++ b/frontend/src/components/pages/Client/main/SectionNews.tsx
@@ -1,9 +1,46 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import CustomLink from "../../../common/CustomLink";
 import styled from "styled-components";
+import { getNews } from "@/api/postApi";
+import { NewsItem } from "@/types/forms";
+
+interface NewsDataProps {
+  date: string;
+  description: string;
+  img: string;
+  link: string;
+  title: string;
+}
+
+const PrevDiv = styled.div`
+  h3 {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    font-weight: 700;
+  }
+`;
+
+const LinkBlog = styled.a`
+  width: 130px;
+  line-height: 2;
+
+  text-decoration: none;
+  display: block;
+  color: #49b736;
+  font-weight: 600;
+  position: relative;
+  svg {
+    position: absolute;
+    top: 50%;
+    right: 0px;
+    transform: translateY(-50%);
+  }
+`;
 
 const Section = styled.section`
-  margin-bottom: 120px;
+  margin-bottom: 70px;
   article {
     display: flex;
     justify-content: space-between;
@@ -13,21 +50,45 @@ const Section = styled.section`
       display: flex;
       flex-direction: column;
       gap: 20px;
+      .newsActive {
+        background-color: #f8f8f8;
+        svg {
+          color: #49b736;
+        }
+      }
       li {
+        width: 100%;
         padding: 16px 40px;
         cursor: pointer;
         border-bottom: 1px solid #dddddd;
+        position: relative;
+        h3 {
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          width: 80%;
+        }
+
+        svg {
+          position: absolute;
+          top: 50%;
+          right: 10px;
+          transform: translateY(-50%);
+          width: 25px;
+          height: 25px;
+          color: #888888;
+        }
       }
     }
     div {
       width: 45%;
       display: flex;
       flex-direction: column;
-      align-items: center;
-
+      justify-content: center;
+      align-items: flex-end;
       p {
         margin-top: 20px;
-        line-height: 1.4;
+        line-height: 2;
       }
     }
 
@@ -35,6 +96,10 @@ const Section = styled.section`
       width: 100%;
     }
   }
+`;
+
+const NewsUl = styled.ul`
+  height: 100%;
 `;
 const Header = styled.div`
   display: flex;
@@ -45,7 +110,23 @@ const Header = styled.div`
   margin-bottom: 30px;
   position: relative;
 `;
+
 export default function SectionNews() {
+  const [newsList, setNewsList] = useState<NewsDataProps[]>([]);
+  const [preview, setPreview] = useState<NewsItem>();
+
+  useEffect(() => {
+    const fetchNews = async () => {
+      const res = await getNews();
+      setNewsList(res.message.slice(0, 4));
+    };
+    fetchNews();
+  }, []);
+
+  useEffect(() => {
+    setPreview(newsList[0]);
+  }, [newsList]);
+
   return (
     <Section>
       <Header>
@@ -53,50 +134,57 @@ export default function SectionNews() {
         <CustomLink to={"news"} />
       </Header>
       <article>
-        <ul>
-          <li>
-            <h3 className="Section-NewsTitle">
-              2025년 봄학기 우즈베키스탄 의대 합격자 명단 발표
-            </h3>
-            <time className="Section-NewsDate" dateTime="2000-01-01">
-              2000-01-01
-            </time>
-          </li>
-          <li>
-            <h3 className="Section-NewsTitle">
-              2025년 봄학기 우즈베키스탄 의대 합격자 명단 발표
-            </h3>
-            <time className="Section-NewsDate" dateTime="2000-01-01">
-              2000-01-01
-            </time>
-          </li>
-          <li>
-            <h3 className="Section-NewsTitle">
-              2025년 봄학기 우즈베키스탄 의대 합격자 명단 발표
-            </h3>
-            <time className="Section-NewsDate" dateTime="2000-01-01">
-              2000-01-01
-            </time>
-          </li>
-          <li>
-            <h3 className="Section-NewsTitle">
-              2025년 봄학기 우즈베키스탄 의대 합격자 명단 발표
-            </h3>
-            <time className="Section-NewsDate" dateTime="2000-01-01">
-              2000-01-01
-            </time>
-          </li>
-        </ul>
-        <div>
-          <img src="./news0.jpg" alt="뉴스기사 이미지" loading="lazy" />
-          <p>
-            드림유학원은 2025년 봄학기 우즈베키스탄 의대 진학 프로그램을 통해 총
-            25명의 학생이 최종 합격했다는 기쁜 소식을 전합니다. 이번 합격자는
-            타슈켄트 국립 의과대학을 비롯한 주요 의대에 고르게 배출되었으며,
-            드림유학원의 전문 상담과 현지 밀착 지원이 큰 역할을 했습니다.
-            앞으로도 학생 여러분의 꿈을 실현할 수 있도록 최선을 다하겠습니다.
-          </p>
-        </div>
+        <NewsUl>
+          {newsList.map((item, index) => {
+            return (
+              <li
+                onClick={() => setPreview(item)}
+                key={index}
+                className={preview?.date === item.date ? "newsActive" : ""}
+              >
+                <h3 className="Section-NewsTitle">{item.title}</h3>
+                <time className="Section-NewsDate" dateTime="2000-01-01">
+                  {item.date}
+                </time>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  className="bi bi-chevron-right"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
+                  />
+                </svg>
+              </li>
+            );
+          })}
+        </NewsUl>
+        <PrevDiv>
+          <h3 className="Section-NewsTitle">{preview?.title}</h3>
+          <p>{preview?.description}</p>
+          {preview && (
+            <LinkBlog href={preview?.link} target="_blank">
+              블로그 바로가기
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                className="bi bi-chevron-right"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"
+                />
+              </svg>
+            </LinkBlog>
+          )}
+        </PrevDiv>
       </article>
     </Section>
   );

--- a/frontend/src/components/pages/Client/main/SectionOffice.tsx
+++ b/frontend/src/components/pages/Client/main/SectionOffice.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import CustomLink from "../../../common/CustomLink";
+import { ImgPreviewStore } from "@/store/userStore";
+import { GetOfficeImages } from "@/api/postApi";
+import { ImageItem } from "@/types/forms";
 
 const Section = styled.section`
   margin-bottom: 120px;
@@ -35,6 +38,19 @@ const Ul = styled.ul`
 `;
 
 export default function SectionOffice() {
+  const { imgList } = ImgPreviewStore();
+  const [OfficeImg, setOfficeImg] = useState<ImageItem[]>();
+  useEffect(() => {
+    const fetchImage = async () => {
+      const response = await GetOfficeImages();
+      setOfficeImg(response.slides);
+    };
+    fetchImage();
+  }, [imgList]);
+
+  useEffect(() => {
+    console.log(OfficeImg);
+  }, [OfficeImg]);
   return (
     <Section>
       <div>
@@ -46,27 +62,17 @@ export default function SectionOffice() {
         <CustomLink to={"office"} />
       </div>
       <Ul>
-        <li>
-          <img
-            src="https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/%E1%84%92%E1%85%A7%E1%86%AB%E1%84%8C%E1%85%B5+%E1%84%89%E1%85%A1%E1%84%86%E1%85%AE%E1%84%89%E1%85%B5%E1%86%AF+0.jpg"
-            alt="타슈켄트 사무소 사진1"
-            loading="lazy"
-          />
-        </li>
-        <li>
-          <img
-            src="https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/%E1%84%92%E1%85%A7%E1%86%AB%E1%84%8C%E1%85%B5+%E1%84%89%E1%85%A1%E1%84%86%E1%85%AE%E1%84%89%E1%85%B5%E1%86%AF+1.JPG"
-            alt="타슈켄트 사무소 사진2"
-            loading="lazy"
-          />
-        </li>
-        <li>
-          <img
-            src="https://dreamcenter-image-bucket.s3.ap-northeast-2.amazonaws.com/uploads/%E1%84%92%E1%85%A7%E1%86%AB%E1%84%8C%E1%85%B5+%E1%84%89%E1%85%A1%E1%84%86%E1%85%AE%E1%84%89%E1%85%B5%E1%86%AF+2.JPG"
-            alt="타슈켄트 사무소 사진3"
-            loading="lazy"
-          />
-        </li>
+        {OfficeImg?.map((item, index) => {
+          return (
+            <li key={index}>
+              <img
+                src={item.image_url}
+                alt="타슈켄트 사무소 사진"
+                loading="lazy"
+              />
+            </li>
+          );
+        })}
       </Ul>
     </Section>
   );

--- a/frontend/src/components/pages/Client/main/SubTitleInputGroup.tsx
+++ b/frontend/src/components/pages/Client/main/SubTitleInputGroup.tsx
@@ -1,0 +1,31 @@
+import { MainStore } from "@/store/userStore";
+import React from "react";
+import styled from "styled-components";
+
+const SingleInput = styled.input`
+  height: 40px;
+  width: 100%;
+  border: 1px solid #dddddd;
+  padding-left: 10px;
+  font-size: 16px;
+`;
+
+export default function SubTitleInputGroup() {
+  const { title2, setTitle2 } = MainStore();
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle2(e.target.value);
+  };
+  return (
+    <>
+      <SingleInput
+        type="text"
+        id="title"
+        name="title"
+        placeholder="서브 타이틀을 입력해주세요"
+        required
+        value={title2}
+        onChange={handleChange}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/pages/Client/main/TitleInputGroup.tsx
+++ b/frontend/src/components/pages/Client/main/TitleInputGroup.tsx
@@ -1,5 +1,5 @@
 import { MainStore } from "@/store/userStore";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 const SingleInput = styled.input`

--- a/frontend/src/components/pages/Client/main/TitleInputGroup.tsx
+++ b/frontend/src/components/pages/Client/main/TitleInputGroup.tsx
@@ -1,0 +1,31 @@
+import { MainStore } from "@/store/userStore";
+import React from "react";
+import styled from "styled-components";
+
+const SingleInput = styled.input`
+  height: 40px;
+  width: 100%;
+  border: 1px solid #dddddd;
+  padding-left: 10px;
+  font-size: 16px;
+`;
+
+export default function TitleInputGroup() {
+  const { title1, setTitle1 } = MainStore();
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle1(e.target.value);
+  };
+  return (
+    <>
+      <SingleInput
+        type="text"
+        id="title"
+        name="title"
+        placeholder="메인 타이틀을 입력해주세요"
+        required
+        value={title1}
+        onChange={handleChange}
+      />
+    </>
+  );
+}

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -65,11 +65,11 @@ export const WriteAboutStore = create<WriteAboutStoreProps>((set) => ({
   setEditSection: (state: boolean) => set({ editSection: state }),
 }));
 
-interface AboutAndOfficeStoreProps {
+interface UseModalStoreProps {
   isModalOpen: boolean;
   setIsModalOpen: (state: boolean) => void;
 }
-export const AboutAndOfficeStore = create<AboutAndOfficeStoreProps>((set) => ({
+export const UseModalStore = create<UseModalStoreProps>((set) => ({
   isModalOpen: false,
   setIsModalOpen: (state: boolean) => set({ isModalOpen: state }),
 }));

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -67,11 +67,19 @@ export const WriteAboutStore = create<WriteAboutStoreProps>((set) => ({
 
 interface UseModalStoreProps {
   isModalOpen: boolean;
+  ImageModal: boolean;
+  ImageSrc: string;
   setIsModalOpen: (state: boolean) => void;
+  setImageModal: (state: boolean) => void;
+  setImageSrc: (state: string) => void;
 }
 export const UseModalStore = create<UseModalStoreProps>((set) => ({
   isModalOpen: false,
+  ImageModal: false,
+  ImageSrc: "",
   setIsModalOpen: (state: boolean) => set({ isModalOpen: state }),
+  setImageModal: (state: boolean) => set({ ImageModal: state }),
+  setImageSrc: (state: string) => set({ ImageSrc: state }),
 }));
 
 type FileItem = {

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -220,9 +220,13 @@ export const QuestionWritePageStore = create<QuestionWritePageProps>((set) => ({
 
 interface ControlModalProps {
   viewModal: boolean;
+  postId: number | null;
   setViewModal: (state: boolean) => void;
+  setPostId: (state: number) => void;
 }
 export const ControlModalStore = create<ControlModalProps>((set) => ({
   viewModal: false,
+  postId: null,
   setViewModal: (state) => set({ viewModal: state }),
+  setPostId: (state) => set({ postId: state }),
 }));

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -253,3 +253,35 @@ export const SearchStore = create<SearchProps>((set) => ({
   setSearchList: (state) => set({ searchList: state }),
   setSearchData: (state) => set({ searchData: state }),
 }));
+
+interface MainProps {
+  title1: string;
+  title2: string;
+  message: string;
+  isModalOpen: boolean;
+  file: FileItem[];
+  setTitle1: (state: string) => void;
+  setTitle2: (state: string) => void;
+  setMessage: (state: string) => void;
+  setIsModalOpen: (state: boolean) => void;
+  setFiles: (value: FileItem[] | ((prev: FileItem[]) => FileItem[])) => void;
+}
+
+export const MainStore = create<MainProps>((set) => ({
+  title1: "",
+  title2: "",
+  message: "",
+  isModalOpen: false,
+  file: [],
+  setTitle1: (state: string) => set({ title1: state }),
+  setTitle2: (state: string) => set({ title2: state }),
+  setMessage: (state: string) => set({ message: state }),
+  setIsModalOpen: (state: boolean) => set({ isModalOpen: state }),
+  setFiles: (updater) =>
+    set((state) => ({
+      file:
+        typeof updater === "function"
+          ? (updater as (prev: FileItem[]) => FileItem[])(state.file)
+          : updater,
+    })),
+}));

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -1,3 +1,4 @@
+import { QuestionData } from "@/types/forms";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -229,4 +230,18 @@ export const ControlModalStore = create<ControlModalProps>((set) => ({
   postId: null,
   setViewModal: (state) => set({ viewModal: state }),
   setPostId: (state) => set({ postId: state }),
+}));
+
+interface SearchProps {
+  searchList: boolean;
+  searchData: QuestionData[];
+  setSearchList: (state: boolean) => void;
+  setSearchData: (state: QuestionData[]) => void;
+}
+
+export const SearchStore = create<SearchProps>((set) => ({
+  searchList: false,
+  searchData: [],
+  setSearchList: (state) => set({ searchList: state }),
+  setSearchData: (state) => set({ searchData: state }),
 }));

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -1,4 +1,4 @@
-import { QuestionData } from "@/types/forms";
+import { MainDataProps, QuestionData } from "@/types/forms";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -260,11 +260,13 @@ interface MainProps {
   message: string;
   isModalOpen: boolean;
   file: FileItem[];
+  MainAbout: MainDataProps;
   setTitle1: (state: string) => void;
   setTitle2: (state: string) => void;
   setMessage: (state: string) => void;
   setIsModalOpen: (state: boolean) => void;
   setFiles: (value: FileItem[] | ((prev: FileItem[]) => FileItem[])) => void;
+  setMainAbout: (state: MainDataProps) => void;
 }
 
 export const MainStore = create<MainProps>((set) => ({
@@ -273,6 +275,13 @@ export const MainStore = create<MainProps>((set) => ({
   message: "",
   isModalOpen: false,
   file: [],
+  MainAbout: {
+    id: 1,
+    title_main: "",
+    title_sub: "",
+    content: "",
+    image_url: "",
+  },
   setTitle1: (state: string) => set({ title1: state }),
   setTitle2: (state: string) => set({ title2: state }),
   setMessage: (state: string) => set({ message: state }),
@@ -284,4 +293,5 @@ export const MainStore = create<MainProps>((set) => ({
           ? (updater as (prev: FileItem[]) => FileItem[])(state.file)
           : updater,
     })),
+  setMainAbout: (state: MainDataProps) => set({ MainAbout: state }),
 }));

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -72,3 +72,19 @@ export type MainDataProps = {
   content: string;
   image_url: string;
 };
+
+export type ImageItem = {
+  id: number;
+  name: string;
+  image_url: string;
+  sort_order: number;
+  created_at: string; // ISO 날짜 문자열 (예: "2025-05-17T16:01:50.000Z")
+};
+
+export type NewsItem = {
+  title: string;
+  description: string;
+  date: string; // 예: "2025.05.01.23:25"
+  img: string; // 썸네일 이미지 URL
+  link: string; // 원문 링크 (네이버 블로그 등)
+};

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -64,3 +64,11 @@ export interface GallerySlide {
   image_url: string;
   created_at: string;
 }
+
+export type MainDataProps = {
+  id: number;
+  title_main: string;
+  title_sub: string;
+  content: string;
+  image_url: string;
+};

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -57,3 +57,10 @@ export interface AnswerData {
   createdAt: string; // 또는 Date
   updatedAt: string; // 또는 Date
 }
+
+export interface GallerySlide {
+  id: number;
+  name: string;
+  image_url: string;
+  created_at: string;
+}

--- a/frontend/src/types/forms.ts
+++ b/frontend/src/types/forms.ts
@@ -49,3 +49,11 @@ export interface FormDataTableFormProps {
   type?: string;
   children?: React.ReactNode;
 }
+
+export interface AnswerData {
+  id: number;
+  question_id: number;
+  content: string;
+  createdAt: string; // 또는 Date
+  updatedAt: string; // 또는 Date
+}


### PR DESCRIPTION
# 구현 기능

<img width="1296" alt="스크린샷 2025-06-04 오전 2 21 58" src="https://github.com/user-attachments/assets/2571e3b2-6788-4546-b119-73fb49759ddf" />

## 질의응답 게시판
- 질의응답 게시판 제작
- 비공개 게시글 비밀번호 입력창 제작
- 질문 자세히보기 페이지 제작
- 관리자 답변달기 기능 제작 

<img width="1296" alt="스크린샷 2025-06-04 오전 2 22 28" src="https://github.com/user-attachments/assets/23daa1f3-61b0-4715-b47f-c4b2d3ff2a4d" />

## 갤러리
- 갤러리 게시판 제작 완료
- 갤러리 이미지 업로드 기능 이미지 슬라이드 업로드 모달의 재 사용으로 빠르게 제작 완료 

<img width="1296" alt="스크린샷 2025-06-04 오전 2 23 29" src="https://github.com/user-attachments/assets/2762d4f0-cd22-4ea6-803c-3a8d0701329d" />

## 메인 페이지
- 메인페이지의 유학원 소개하는 섹션의 멘트 설정 모달 제작 완료 
- 배경 이미지도 교체 가능하도록 이미지 설정 연결
- 뉴스 섹션 블로그 동기화 완료 및 미리보기와 블로그 바로가기 기능 구현
- 이미지 갤러리 그리드 라이브러리 활용해서 제작 완료 
- 
## 특이사항

<img width="1296" alt="스크린샷 2025-06-04 오전 2 25 10" src="https://github.com/user-attachments/assets/44b594ee-fd4c-4d55-86f0-058fd0529728" />

### 이미지 갤러리
초기에는 
- 갤러리 페이지 : 바둑판 형식 + 페이지 카운트 UI로 9개씩 보여주기
- 메인 페이지의 갤러리 섹션 : 그리드 형식으로 핀터레스트 레이아웃 활용 
하지만 메인 페이지의 깔끔함을 유지하고, 이미지 갤러리 페이지에서의 용이하게 보여주기 위한 편의를 챙기기 위해 
둘을 교체하기로 결정
메인 페이지에는 8개의 바둑판 형식으로 , 이미지 갤러리에는 그리드 형식으로 교환

<img width="1296" alt="스크린샷 2025-06-04 오전 2 24 46" src="https://github.com/user-attachments/assets/c6a3dc30-cd88-4bea-bbd4-8dae2d720fba" />

### 블로그 동기화
- 본래 블로그의 이미지를 동기화 시켜 곧바로 src를 통해 사진을 띄울 예정
- 하지만 네이버의 정책 문제로 이미지를 띄우지 못한다는 사실을 알게됨
- 디자인 수정을 통해 이미지 대신 기사 제목을 띄우고 블로그 바로가기 버튼을 추가해서 보완함