### PR TITLE
fix:관리자 인증 email -> sns_id로 인증방식 변경 및 네이버 유저 데이터 축소

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -18,27 +18,27 @@ module.exports = (sequelize, DataTypes) => {
     nickname: {
       type: DataTypes.STRING,
     },
-    email: {
-      type: DataTypes.STRING,
-    },
-    profile_image: {
-      type: DataTypes.STRING,
-    },
-    age: {
-      type: DataTypes.STRING,
-    },
-    gender: {
-      type: DataTypes.STRING,
-    },
-    mobile: {
-      type: DataTypes.STRING,
-    },
-    birthyear: {
-      type: DataTypes.STRING,
-    },
-    birthday: {
-      type: DataTypes.STRING,
-    },
+    // email: {
+    //   type: DataTypes.STRING,
+    // },
+    // profile_image: {
+    //   type: DataTypes.STRING,
+    // },
+    // age: {
+    //   type: DataTypes.STRING,
+    // },
+    // gender: {
+    //   type: DataTypes.STRING,
+    // },
+    // mobile: {
+    //   type: DataTypes.STRING,
+    // },
+    // birthyear: {
+    //   type: DataTypes.STRING,
+    // },
+    // birthday: {
+    //   type: DataTypes.STRING,
+    // },
     role: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/frontend/src/components/common/LoginInitializer.tsx
+++ b/frontend/src/components/common/LoginInitializer.tsx
@@ -45,7 +45,6 @@ export default function LoginInitializer() {
     const fetchLoginState = async () => {
       try {
         const res = await checkLoginStatus(); // 로그인 가능 상태 확인
-
         if (res.code === "TOKEN_EXPIRED") {
           naverLogin();
         } else if (res.code === "SUCCESS") {
@@ -55,6 +54,8 @@ export default function LoginInitializer() {
           setUser_id(res.sns_id);
         } else if (res.code === "NO_TOKEN") {
           naverLogin();
+        } else if (res.code === "NO_USER") {
+          naverLogin();
         }
       } catch (e) {
         console.error("로그인 상태 확인 실패", e);
@@ -62,13 +63,14 @@ export default function LoginInitializer() {
         setIsLoginChecked(true); // 모든 판단 완료 후 여타 컴포넌트 진입
       }
     };
+
     if (PathArr.includes(location.pathname)) {
       fetchLoginState();
     } else {
       setIsLoginChecked(true); // 예외 url은 바로 진입
       const fetchLogin = async () => {
         const res = await checkLoginStatus();
-        if (res.code === "SUCCESS") {
+        if (res?.code === "SUCCESS") {
           setIsLogin(true);
           setUserName(res.name);
           setRole(res.role);

--- a/frontend/src/components/pages/Client/GalleryPage.tsx
+++ b/frontend/src/components/pages/Client/GalleryPage.tsx
@@ -91,6 +91,7 @@ export default function GalleryPage() {
           />
         ))}
       </Masonry>
+      {isModalOpen && <EditModal />}
     </Div>
   );
 }

--- a/frontend/src/components/pages/Client/LocationPage.tsx
+++ b/frontend/src/components/pages/Client/LocationPage.tsx
@@ -204,7 +204,6 @@ export default function LocationPage() {
     const fetchData = async () => {
       const res = await GetLocation();
       if (res.result) {
-        console.log(res.result);
         setAddress(res.result.address);
         setEditAdress(res.result.address);
         setEditPhone1(res.result.phone1);

--- a/frontend/src/components/pages/Client/Reservation/FormSection.tsx
+++ b/frontend/src/components/pages/Client/Reservation/FormSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { SetStateAction, useState } from "react";
 import styled from "styled-components";
 
 import "react-datepicker/dist/react-datepicker.css";
@@ -143,8 +143,10 @@ const PrivacyBox = styled.div`
     flex-shrink: 0;
   }
 `;
-
-export default function FormSection() {
+type props = {
+  setSelectTab: React.Dispatch<SetStateAction<boolean>>;
+};
+export default function FormSection({ setSelectTab }: props) {
   const { setViewModal, setType } = ControlModalStore();
   const { showAlert } = useAlertStore();
   const {
@@ -200,8 +202,9 @@ export default function FormSection() {
       formData.append("images", file);
     });
     const res = await PostReservation(formData);
-    alert(res?.data.message);
+    showAlert(res?.data.message);
     resetForm();
+    setSelectTab(false);
   };
 
   const handlePrivacy = () => {

--- a/frontend/src/components/pages/Client/ReservationPage.tsx
+++ b/frontend/src/components/pages/Client/ReservationPage.tsx
@@ -38,7 +38,7 @@ export default function ReservationPage() {
         setSelectTab={setSelectTab}
       />
       {selectTab ? (
-        <FormSection />
+        <FormSection setSelectTab={setSelectTab} />
       ) : (
         <MyListSection form={form} setForm={setForm} />
       )}


### PR DESCRIPTION
# 기능 수정
- 기존 네이버 유저 데이터가 대부분 쓰이지않는 정보라고 판단 > 데이터 범위 축소와 DB 테이블 변경
- 관리자 지정 판별을 유저의 email로 하던 기존 방식에서 고유한 값인 sns_id로 변경
- 모달창 수정 및  질문 등록 확인 등등 수정 완료